### PR TITLE
Clarify options description for 'days until delete' (fix #26)

### DIFF
--- a/src/frontend/options/options.tsx
+++ b/src/frontend/options/options.tsx
@@ -168,7 +168,7 @@ function App() {
                 class="w-20 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
               />
               <p class="text-xs text-gray-500 mt-1">
-                既読エントリをこの日数経過後に自動で削除します
+                既読にしてからこの日数経過後に自動で削除します
               </p>
             </div>
           </div>


### PR DESCRIPTION
This PR clarifies the options UI text for the "Days until delete" field to match the implementation: the deletion is determined based on `lastUpdateTime`, i.e. the number of days after an entry is marked as read.

- Update `src/frontend/options/options.tsx` to change the description text to: "既読にしてからこの日数経過後に自動で削除します".

Resolves: #26