### PR TITLE
feat: make Slack message titles bold for better visibility

### DIFF
--- a/src/backend/summarizer.ts
+++ b/src/backend/summarizer.ts
@@ -124,7 +124,7 @@ export async function summarizeContent(
 /**
  * Slack投稿用のメッセージフォーマットを生成
  * フォーマット:
- * {title}
+ * *{title}*
  * {url}
  *
  * {model_name}による要約
@@ -137,7 +137,7 @@ export function formatSlackMessage(
   modelName: string,
   summary: string,
 ): string {
-  return `${title}
+  return `*${title}*
 ${url}
 
 ${modelName}による要約
@@ -154,7 +154,7 @@ export function formatSlackErrorMessage(
   modelName: string,
   error: string,
 ): string {
-  return `${title}
+  return `*${title}*
 ${url}
 
 ${modelName}による要約

--- a/tests/backend/summarizer.test.ts
+++ b/tests/backend/summarizer.test.ts
@@ -255,7 +255,7 @@ describe("summarizer", () => {
       );
 
       expect(result).toBe(
-        "テストタイトル\n" +
+        "*テストタイトル*\n" +
           "https://example.com\n" +
           "\n" +
           "gpt-4による要約\n" +
@@ -273,7 +273,7 @@ describe("summarizer", () => {
       );
 
       expect(result).toBe(
-        "テストタイトル\n" +
+        "*テストタイトル*\n" +
           "https://example.com\n" +
           "\n" +
           "gpt-4による要約\n" +
@@ -293,7 +293,7 @@ describe("summarizer", () => {
       );
 
       expect(result).toBe(
-        "テストタイトル\n" +
+        "*テストタイトル*\n" +
           "https://example.com\n" +
           "\n" +
           "gpt-4による要約\n" +


### PR DESCRIPTION
fix: #30 AIによる自動PR

## 実装内容

Slackに投稿されるメッセージのタイトルを太字にして視認性を向上させました。

### 変更点
- `formatSlackMessage`関数でタイトルをアスタリスク(`*title*`)で囲み、Slack上で太字表示されるように修正
- `formatSlackErrorMessage`関数でも同様の太字フォーマットを適用（一貫性のため）
- 対応するテストケースの期待値を更新

### 実装にあたって参考にした情報・注意点
- SlackのMarkdown記法では、アスタリスク(`*`)で囲んだテキストが太字になることを活用
- 既存のメッセージフォーマットの構造は維持し、タイトル部分のみ太字化
- エラーメッセージでも同様の太字フォーマットを適用して、UIの一貫性を保持
- すべてのテストが正常に通ることを確認

### 実装にあたっての質問・懸念点
- なし（シンプルな文字列フォーマットの変更のため、特に懸念はありません）

## テスト結果
- 全61テスト成功
- TypeScriptの型チェック正常
- Biomeによるlint/formatチェック正常
- ビルド成功