### PR TITLE
feat: make alarm interval configurable from options

### DIFF
--- a/src/backend/alarm.ts
+++ b/src/backend/alarm.ts
@@ -1,10 +1,12 @@
-import { getSettings, validateSettings } from "../common/chrome_storage";
+import {
+  DEFAULT_INTERVAL_MINUTES,
+  getSettings,
+  validateSettings,
+} from "../common/chrome_storage";
 import { processReadingListEntries } from "./background";
 
 // Chrome拡張のアラーム設定
 const ALARM_NAME = "readingListAutoProcess";
-// デフォルトの実行間隔（chrome_storage.DEFAULT_SETTINGS と同値）
-const DEFAULT_INTERVAL_MINUTES = 720;
 
 /**
  * ランタイム環境の検出

--- a/src/common/chrome_storage.ts
+++ b/src/common/chrome_storage.ts
@@ -2,6 +2,7 @@ export interface Settings {
   daysUntilRead: number;
   daysUntilDelete: number;
   maxEntriesPerRun?: number;
+  alarmIntervalMinutes?: number;
   openaiEndpoint?: string;
   openaiApiKey?: string;
   openaiModel?: string;
@@ -32,6 +33,7 @@ export const DEFAULT_SETTINGS: Settings = {
   daysUntilRead: 30,
   daysUntilDelete: DELETION_DISABLED_VALUE,
   maxEntriesPerRun: 3,
+  alarmIntervalMinutes: 720,
 };
 
 /**
@@ -43,6 +45,7 @@ export async function getSettings(): Promise<Settings> {
       "daysUntilRead",
       "daysUntilDelete",
       "maxEntriesPerRun",
+      "alarmIntervalMinutes",
       "openaiEndpoint",
       "openaiApiKey",
       "openaiModel",
@@ -57,6 +60,8 @@ export async function getSettings(): Promise<Settings> {
         result.daysUntilDelete ?? DEFAULT_SETTINGS.daysUntilDelete,
       maxEntriesPerRun:
         result.maxEntriesPerRun ?? DEFAULT_SETTINGS.maxEntriesPerRun,
+      alarmIntervalMinutes:
+        result.alarmIntervalMinutes ?? DEFAULT_SETTINGS.alarmIntervalMinutes,
       openaiEndpoint: result.openaiEndpoint,
       openaiApiKey: result.openaiApiKey,
       openaiModel: result.openaiModel,
@@ -83,6 +88,11 @@ export async function saveSettings(settings: Settings): Promise<void> {
     // maxEntriesPerRun は必須項目として保存
     if (settings.maxEntriesPerRun !== undefined) {
       settingsToSave.maxEntriesPerRun = settings.maxEntriesPerRun;
+    }
+
+    // alarmIntervalMinutes は必須項目として保存
+    if (settings.alarmIntervalMinutes !== undefined) {
+      settingsToSave.alarmIntervalMinutes = settings.alarmIntervalMinutes;
     }
 
     // オプション項目は値が存在する場合のみ保存
@@ -147,6 +157,15 @@ export function validateSettings(settings: Partial<Settings>): string[] {
       errors.push(
         "1回の実行で既読にする最大エントリ数は1-100の整数で入力してください",
       );
+    }
+  }
+
+  if (settings.alarmIntervalMinutes !== undefined) {
+    if (
+      !Number.isInteger(settings.alarmIntervalMinutes) ||
+      settings.alarmIntervalMinutes < 1
+    ) {
+      errors.push("実行間隔（分）は1以上の整数で入力してください");
     }
   }
 

--- a/src/common/chrome_storage.ts
+++ b/src/common/chrome_storage.ts
@@ -11,6 +11,9 @@ export interface Settings {
   systemPrompt?: string;
 }
 
+// 実行間隔（分）のデフォルト値
+export const DEFAULT_INTERVAL_MINUTES = 720;
+
 // デフォルトのシステムプロンプト
 export const DEFAULT_SYSTEM_PROMPT =
   "テキストから本文を抜き出し、日本語で要約してください。\n" +
@@ -33,7 +36,7 @@ export const DEFAULT_SETTINGS: Settings = {
   daysUntilRead: 30,
   daysUntilDelete: DELETION_DISABLED_VALUE,
   maxEntriesPerRun: 3,
-  alarmIntervalMinutes: 720,
+  alarmIntervalMinutes: DEFAULT_INTERVAL_MINUTES,
 };
 
 /**

--- a/src/frontend/options/options.tsx
+++ b/src/frontend/options/options.tsx
@@ -123,6 +123,30 @@ function App() {
           <div class="grid gap-4">
             <div>
               <label
+                for="alarmIntervalMinutes"
+                class="block text-sm font-medium text-gray-700 mb-1"
+              >
+                実行間隔（分）
+              </label>
+              <input
+                id="alarmIntervalMinutes"
+                type="number"
+                min="1"
+                value={settings.alarmIntervalMinutes ?? 720}
+                onInput={(e) =>
+                  handleInputChange(
+                    "alarmIntervalMinutes",
+                    Number((e.target as HTMLInputElement).value),
+                  )
+                }
+                class="w-24 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+              <p class="text-xs text-gray-500 mt-1">
+                バックグラウンドの自動処理を起動する間隔（分）。最小1分。
+              </p>
+            </div>
+            <div>
+              <label
                 for="daysUntilRead"
                 class="block text-sm font-medium text-gray-700 mb-1"
               >

--- a/src/frontend/options/options.tsx
+++ b/src/frontend/options/options.tsx
@@ -132,7 +132,10 @@ function App() {
                 id="alarmIntervalMinutes"
                 type="number"
                 min="1"
-                value={settings.alarmIntervalMinutes ?? 720}
+                value={
+                  settings.alarmIntervalMinutes ??
+                  DEFAULT_SETTINGS.alarmIntervalMinutes
+                }
                 onInput={(e) =>
                   handleInputChange(
                     "alarmIntervalMinutes",

--- a/tests/backend/alarm.test.ts
+++ b/tests/backend/alarm.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("alarm.setupAlarm", () => {
+  const mockChromeAlarms = {
+    clear: vi.fn(),
+    create: vi.fn(),
+    onAlarm: { addListener: vi.fn() },
+  };
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.stubGlobal("chrome", {
+      alarms: mockChromeAlarms,
+      runtime: {
+        onInstalled: { addListener: vi.fn() },
+        onStartup: { addListener: vi.fn() },
+        onMessage: { addListener: vi.fn() },
+      },
+    } as unknown as typeof chrome);
+  });
+
+  it("保存された実行間隔を使用してアラームを設定する", async () => {
+    // getSettings をモック
+    vi.doMock("../../src/common/chrome_storage", () => ({
+      getSettings: async () => ({
+        alarmIntervalMinutes: 15,
+        daysUntilRead: 30,
+        daysUntilDelete: -1,
+      }),
+      validateSettings: (_s: unknown) => [],
+    }));
+
+    // 再インポートしてモック反映
+    const { setupAlarm: setup } = await import("../../src/backend/alarm");
+
+    await setup();
+
+    expect(mockChromeAlarms.clear).toHaveBeenCalledWith(
+      "readingListAutoProcess",
+    );
+    expect(mockChromeAlarms.create).toHaveBeenCalledWith(
+      "readingListAutoProcess",
+      {
+        delayInMinutes: 1,
+        periodInMinutes: 15,
+      },
+    );
+  });
+
+  it("不正な間隔や取得失敗時はデフォルト720分を使用する", async () => {
+    vi.doMock("../../src/common/chrome_storage", () => ({
+      getSettings: async () => ({
+        alarmIntervalMinutes: 0,
+        daysUntilRead: 30,
+        daysUntilDelete: -1,
+      }),
+      validateSettings: (_s: unknown) => ["invalid"],
+    }));
+
+    const { setupAlarm: setup } = await import("../../src/backend/alarm");
+
+    await setup();
+
+    expect(mockChromeAlarms.create).toHaveBeenCalledWith(
+      "readingListAutoProcess",
+      {
+        delayInMinutes: 1,
+        periodInMinutes: 720,
+      },
+    );
+  });
+});

--- a/tests/backend/alarm.test.ts
+++ b/tests/backend/alarm.test.ts
@@ -29,6 +29,7 @@ describe("alarm.setupAlarm", () => {
         daysUntilDelete: -1,
       }),
       validateSettings: (_s: unknown) => [],
+      DEFAULT_INTERVAL_MINUTES: 720,
     }));
 
     // 再インポートしてモック反映
@@ -56,6 +57,7 @@ describe("alarm.setupAlarm", () => {
         daysUntilDelete: -1,
       }),
       validateSettings: (_s: unknown) => ["invalid"],
+      DEFAULT_INTERVAL_MINUTES: 720,
     }));
 
     const { setupAlarm: setup } = await import("../../src/backend/alarm");

--- a/tests/backend/background.test.ts
+++ b/tests/backend/background.test.ts
@@ -76,17 +76,13 @@ describe("getSettings", () => {
       daysUntilRead: 30,
       daysUntilDelete: DELETION_DISABLED_VALUE,
       maxEntriesPerRun: 3,
-      openaiEndpoint: undefined,
-      openaiApiKey: undefined,
-      openaiModel: undefined,
-      slackWebhookUrl: undefined,
-      firecrawlApiKey: undefined,
-      systemPrompt: undefined,
+      alarmIntervalMinutes: 720,
     });
     expect(mockChromeStorageLocal.get).toHaveBeenCalledWith([
       "daysUntilRead",
       "daysUntilDelete",
       "maxEntriesPerRun",
+      "alarmIntervalMinutes",
       "openaiEndpoint",
       "openaiApiKey",
       "openaiModel",
@@ -101,6 +97,7 @@ describe("getSettings", () => {
       daysUntilRead: 14,
       daysUntilDelete: 30,
       maxEntriesPerRun: 5,
+      alarmIntervalMinutes: 720,
       openaiEndpoint: "https://api.openai.com/v1",
       openaiApiKey: "test-key",
       openaiModel: "gpt-3.5-turbo",
@@ -124,6 +121,7 @@ describe("getSettings", () => {
       daysUntilRead: 30,
       daysUntilDelete: DELETION_DISABLED_VALUE,
       maxEntriesPerRun: 3,
+      alarmIntervalMinutes: 720,
     });
   });
 });

--- a/tests/common/chrome_storage.test.ts
+++ b/tests/common/chrome_storage.test.ts
@@ -39,6 +39,7 @@ describe("chrome_storage", () => {
         "daysUntilRead",
         "daysUntilDelete",
         "maxEntriesPerRun",
+        "alarmIntervalMinutes",
         "openaiEndpoint",
         "openaiApiKey",
         "openaiModel",
@@ -53,6 +54,7 @@ describe("chrome_storage", () => {
         daysUntilRead: 45,
         daysUntilDelete: 90,
         maxEntriesPerRun: 5,
+        alarmIntervalMinutes: 120,
         openaiEndpoint: "https://api.example.com/v1",
         openaiApiKey: "sk-test123",
         openaiModel: "gpt-4",
@@ -88,6 +90,7 @@ describe("chrome_storage", () => {
         daysUntilRead: 20,
         daysUntilDelete: 40,
         maxEntriesPerRun: 5,
+        alarmIntervalMinutes: 60,
       };
 
       await saveSettings(settings);
@@ -96,6 +99,7 @@ describe("chrome_storage", () => {
         daysUntilRead: 20,
         daysUntilDelete: 40,
         maxEntriesPerRun: 5,
+        alarmIntervalMinutes: 60,
       });
     });
 
@@ -104,6 +108,7 @@ describe("chrome_storage", () => {
         daysUntilRead: 20,
         daysUntilDelete: 40,
         maxEntriesPerRun: 7,
+        alarmIntervalMinutes: 15,
         openaiEndpoint: "https://api.openai.com/v1",
         openaiApiKey: "sk-test123",
         openaiModel: "gpt-4",
@@ -118,6 +123,7 @@ describe("chrome_storage", () => {
         daysUntilRead: 20,
         daysUntilDelete: 40,
         maxEntriesPerRun: 7,
+        alarmIntervalMinutes: 15,
         openaiEndpoint: "https://api.openai.com/v1",
         openaiApiKey: "sk-test123",
         openaiModel: "gpt-4",
@@ -132,6 +138,7 @@ describe("chrome_storage", () => {
         daysUntilRead: 20,
         daysUntilDelete: 40,
         maxEntriesPerRun: 3,
+        alarmIntervalMinutes: 720,
         openaiEndpoint: "",
         openaiApiKey: "",
         openaiModel: "",
@@ -146,6 +153,7 @@ describe("chrome_storage", () => {
         daysUntilRead: 20,
         daysUntilDelete: 40,
         maxEntriesPerRun: 3,
+        alarmIntervalMinutes: 720,
       });
     });
 
@@ -154,6 +162,7 @@ describe("chrome_storage", () => {
         daysUntilRead: 20,
         daysUntilDelete: 40,
         maxEntriesPerRun: 3,
+        alarmIntervalMinutes: 60,
       };
       const error = new Error("Storage error");
       mockChromeStorage.local.set.mockRejectedValue(error);
@@ -173,6 +182,7 @@ describe("chrome_storage", () => {
         daysUntilRead: 30,
         daysUntilDelete: 60,
         maxEntriesPerRun: 5,
+        alarmIntervalMinutes: 720,
         openaiEndpoint: "https://api.openai.com/v1",
         slackWebhookUrl: "https://hooks.slack.com/services/test",
       };
@@ -270,11 +280,12 @@ describe("chrome_storage", () => {
       const errors = validateSettings({
         daysUntilRead: 0,
         daysUntilDelete: 366,
+        alarmIntervalMinutes: 0,
         openaiEndpoint: "invalid",
         slackWebhookUrl: "also-invalid",
       });
 
-      expect(errors).toHaveLength(4);
+      expect(errors).toHaveLength(5);
     });
   });
 });


### PR DESCRIPTION
fix: #33 AIによる自動PR
codex-cli + GPT-5

実装内容
- ストレージに alarmIntervalMinutes を追加（デフォルト720、バリデーション追加）
- オプション画面に「実行間隔（分）」入力欄を追加
- アラームロジックで保存値を使用（不正・未設定時は720へフォールバック）
- テスト追加・更新（storage/background/alarm）

注意点・参考
- validateSettings は exactOptionalPropertyTypes を考慮し Partial<Settings> を渡しています
- 既存のアラームは setup 時に clear し、delay 1分後に初回、その後 period で実行されます

懸念点/質問
- UI上の説明文・ラベルの表現（日本語）について改善案があればフィードバックください
