### PR TITLE
feat: FirecrawlのBase URLをオプションに追加してセルフホスト版Firecrawlを利用可能に

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ ReadingListAutoSummaryは、Chromeの標準リーディングリスト機能（`
     - APIキー
     - モデル名
     - Slack Webhook URL
+    - Firecrawl Base URL（デフォルト: https://api.firecrawl.dev）
 
 - **ユーザーインターフェース**  
   - 基本的にUIは不要
@@ -75,6 +76,11 @@ ReadingListAutoSummaryは、Chromeの標準リーディングリスト機能（`
 - OpenAI SDK（OpenAI互換API対応）
 - Slack Webhook
 - chrome.storage.local（設定保存）
+
+## Firecrawlの利用
+
+- 既定のBase URLは `https://api.firecrawl.dev` です。オプション画面で Base URL を変更すれば、`http://localhost:3002` などセルフホストした Firecrawl サーバーにも接続できます。
+- セルフホスト環境では `Authorization` ヘッダーの値に任意の文字列を指定できますが、フォームには空でない値を入力してください。
 
 ## 今後の拡張予定
 

--- a/src/backend/background.ts
+++ b/src/backend/background.ts
@@ -4,6 +4,7 @@ import {
   getSettings,
   type Settings,
 } from "../common/chrome_storage";
+import { DEFAULT_FIRECRAWL_BASE_URL } from "../common/constants";
 import type {
   FrontendMessage,
   ManualExecuteResult,
@@ -119,7 +120,11 @@ async function handleExtractContentMessage(
       };
     }
 
-    return await extractContent(url, settings.firecrawlApiKey);
+    return await extractContent(
+      url,
+      settings.firecrawlApiKey,
+      settings.firecrawlBaseUrl || DEFAULT_FIRECRAWL_BASE_URL,
+    );
   } catch (error) {
     return {
       success: false,
@@ -287,6 +292,7 @@ async function processContentExtraction(
   const extractResult = await extractContent(
     entry.url,
     settings.firecrawlApiKey,
+    settings.firecrawlBaseUrl || DEFAULT_FIRECRAWL_BASE_URL,
   );
 
   if (!extractResult.success || !extractResult.content) {

--- a/src/common/chrome_storage.ts
+++ b/src/common/chrome_storage.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_FIRECRAWL_BASE_URL } from "./constants";
+
 export interface Settings {
   daysUntilRead: number;
   daysUntilDelete: number;
@@ -8,6 +10,7 @@ export interface Settings {
   openaiModel?: string;
   slackWebhookUrl?: string;
   firecrawlApiKey?: string;
+  firecrawlBaseUrl?: string;
   systemPrompt?: string;
 }
 
@@ -37,6 +40,7 @@ export const DEFAULT_SETTINGS: Settings = {
   daysUntilDelete: DELETION_DISABLED_VALUE,
   maxEntriesPerRun: 3,
   alarmIntervalMinutes: DEFAULT_INTERVAL_MINUTES,
+  firecrawlBaseUrl: DEFAULT_FIRECRAWL_BASE_URL,
 };
 
 /**
@@ -54,6 +58,7 @@ export async function getSettings(): Promise<Settings> {
       "openaiModel",
       "slackWebhookUrl",
       "firecrawlApiKey",
+      "firecrawlBaseUrl",
       "systemPrompt",
     ]);
 
@@ -70,6 +75,7 @@ export async function getSettings(): Promise<Settings> {
       openaiModel: result.openaiModel,
       slackWebhookUrl: result.slackWebhookUrl,
       firecrawlApiKey: result.firecrawlApiKey,
+      firecrawlBaseUrl: result.firecrawlBaseUrl || DEFAULT_FIRECRAWL_BASE_URL,
       systemPrompt: result.systemPrompt,
     };
   } catch (error) {
@@ -113,6 +119,9 @@ export async function saveSettings(settings: Settings): Promise<void> {
     }
     if (settings.firecrawlApiKey) {
       settingsToSave.firecrawlApiKey = settings.firecrawlApiKey;
+    }
+    if (settings.firecrawlBaseUrl) {
+      settingsToSave.firecrawlBaseUrl = settings.firecrawlBaseUrl;
     }
     if (settings.systemPrompt !== undefined) {
       settingsToSave.systemPrompt = settings.systemPrompt;
@@ -194,6 +203,20 @@ export function validateSettings(settings: Partial<Settings>): string[] {
       }
     } catch {
       errors.push("Slack Webhook URLは有効なURLで入力してください");
+    }
+  }
+
+  if (
+    settings.firecrawlBaseUrl !== undefined &&
+    settings.firecrawlBaseUrl.trim() !== ""
+  ) {
+    try {
+      const url = new URL(settings.firecrawlBaseUrl);
+      if (url.protocol !== "http:" && url.protocol !== "https:") {
+        errors.push("Firecrawl Base URLはhttpまたはhttpsで指定してください");
+      }
+    } catch {
+      errors.push("Firecrawl Base URLは有効なURLで入力してください");
     }
   }
 

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_FIRECRAWL_BASE_URL = "https://api.firecrawl.dev";

--- a/src/frontend/options/options.tsx
+++ b/src/frontend/options/options.tsx
@@ -10,6 +10,7 @@ import {
   saveSettings as saveSettingsToStorage,
   validateSettings,
 } from "../../common/chrome_storage";
+import { DEFAULT_FIRECRAWL_BASE_URL } from "../../common/constants";
 import { ContentExtractorTest } from "./ContentExtractorTest";
 
 type SaveStatus = "idle" | "success" | "error";
@@ -35,6 +36,8 @@ function App() {
         openaiModel: loadedSettings.openaiModel || "",
         slackWebhookUrl: loadedSettings.slackWebhookUrl || "",
         firecrawlApiKey: loadedSettings.firecrawlApiKey || "",
+        firecrawlBaseUrl:
+          loadedSettings.firecrawlBaseUrl || DEFAULT_FIRECRAWL_BASE_URL,
         systemPrompt: loadedSettings.systemPrompt || DEFAULT_SYSTEM_PROMPT,
       });
     } catch (error) {
@@ -52,8 +55,14 @@ function App() {
     setSaveStatus("idle");
     setSaveMessage("");
 
+    const sanitizedSettings: Settings = {
+      ...settings,
+      firecrawlBaseUrl:
+        settings.firecrawlBaseUrl?.trim() || DEFAULT_FIRECRAWL_BASE_URL,
+    };
+
     // バリデーション
-    const validationErrors = validateSettings(settings);
+    const validationErrors = validateSettings(sanitizedSettings);
     if (validationErrors.length > 0) {
       setSaveStatus("error");
       setSaveMessage(
@@ -64,7 +73,8 @@ function App() {
     }
 
     try {
-      await saveSettingsToStorage(settings);
+      await saveSettingsToStorage(sanitizedSettings);
+      setSettings(sanitizedSettings);
       setSaveStatus("success");
       setSaveMessage("設定を保存しました。");
       setTimeout(() => {
@@ -412,6 +422,31 @@ function App() {
             />
             <p class="text-xs text-gray-500 mt-1">
               Webページからのテキスト抽出に使用
+            </p>
+          </div>
+
+          <div>
+            <label
+              for="firecrawlBaseUrl"
+              class="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Firecrawl Base URL
+            </label>
+            <input
+              id="firecrawlBaseUrl"
+              type="url"
+              placeholder="https://api.firecrawl.dev"
+              value={settings.firecrawlBaseUrl}
+              onInput={(e) =>
+                handleInputChange(
+                  "firecrawlBaseUrl",
+                  (e.target as HTMLInputElement).value,
+                )
+              }
+              class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <p class="text-xs text-gray-500 mt-1">
+              セルフホスト環境では `http://localhost:3002` などに変更できます
             </p>
           </div>
         </section>

--- a/tests/backend/background.test.ts
+++ b/tests/backend/background.test.ts
@@ -11,6 +11,7 @@ import {
   DELETION_DISABLED_VALUE,
   getSettings,
 } from "../../src/common/chrome_storage";
+import { DEFAULT_FIRECRAWL_BASE_URL } from "../../src/common/constants";
 
 // content_extractor モジュールのモック
 vi.mock("../../src/backend/content_extractor", () => ({
@@ -77,6 +78,7 @@ describe("getSettings", () => {
       daysUntilDelete: DELETION_DISABLED_VALUE,
       maxEntriesPerRun: 3,
       alarmIntervalMinutes: 720,
+      firecrawlBaseUrl: DEFAULT_FIRECRAWL_BASE_URL,
     });
     expect(mockChromeStorageLocal.get).toHaveBeenCalledWith([
       "daysUntilRead",
@@ -88,6 +90,7 @@ describe("getSettings", () => {
       "openaiModel",
       "slackWebhookUrl",
       "firecrawlApiKey",
+      "firecrawlBaseUrl",
       "systemPrompt",
     ]);
   });
@@ -103,6 +106,7 @@ describe("getSettings", () => {
       openaiModel: "gpt-3.5-turbo",
       slackWebhookUrl: "https://hooks.slack.com/test",
       firecrawlApiKey: "fc-test-key",
+      firecrawlBaseUrl: "http://localhost:3002",
       systemPrompt: "カスタムプロンプト",
     };
     mockChromeStorageLocal.get.mockResolvedValue(storedSettings);
@@ -122,6 +126,7 @@ describe("getSettings", () => {
       daysUntilDelete: DELETION_DISABLED_VALUE,
       maxEntriesPerRun: 3,
       alarmIntervalMinutes: 720,
+      firecrawlBaseUrl: DEFAULT_FIRECRAWL_BASE_URL,
     });
   });
 });
@@ -300,6 +305,7 @@ describe("markAsReadAndNotify", () => {
     openaiModel: "gpt-4o-mini",
     slackWebhookUrl: "https://hooks.slack.com/test",
     firecrawlApiKey: "fc-test-key",
+    firecrawlBaseUrl: DEFAULT_FIRECRAWL_BASE_URL,
   };
 
   it("エントリを正常に既読化", async () => {
@@ -339,6 +345,7 @@ describe("markAsReadAndNotify", () => {
     expect(mockExtractContent).toHaveBeenCalledWith(
       entry.url,
       incompleteSettings.firecrawlApiKey,
+      DEFAULT_FIRECRAWL_BASE_URL,
     );
     // 要約機能は呼ばれない
     expect(mockSummarizeContent).not.toHaveBeenCalled();

--- a/tests/backend/message_handling.test.ts
+++ b/tests/backend/message_handling.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ExtractContentResult } from "../../src/backend/content_extractor";
+import { DEFAULT_FIRECRAWL_BASE_URL } from "../../src/common/constants";
 import type { ManualExecuteResult } from "../../src/types/messages";
 
 // ExtractContent モックの設定
@@ -76,6 +77,7 @@ describe("Message handling", () => {
     // 設定のモック
     mockChromeStorageLocal.get.mockResolvedValue({
       firecrawlApiKey: "fc-test-key",
+      firecrawlBaseUrl: "http://localhost:3002",
     });
 
     // extractContent のモック
@@ -112,6 +114,7 @@ describe("Message handling", () => {
       expect(mockExtractContent).toHaveBeenCalledWith(
         "https://example.com",
         "fc-test-key",
+        "http://localhost:3002",
       );
 
       // sendResponse が正しい結果で呼ばれることを確認
@@ -159,6 +162,7 @@ describe("Message handling", () => {
     // 設定のモック
     mockChromeStorageLocal.get.mockResolvedValue({
       firecrawlApiKey: "fc-test-key",
+      firecrawlBaseUrl: DEFAULT_FIRECRAWL_BASE_URL,
     });
 
     // extractContent のエラーモック

--- a/tests/common/chrome_storage.test.ts
+++ b/tests/common/chrome_storage.test.ts
@@ -6,6 +6,7 @@ import {
   saveSettings,
   validateSettings,
 } from "../../src/common/chrome_storage";
+import { DEFAULT_FIRECRAWL_BASE_URL } from "../../src/common/constants";
 
 // Chrome APIのモック
 const mockChromeStorage = {
@@ -45,6 +46,7 @@ describe("chrome_storage", () => {
         "openaiModel",
         "slackWebhookUrl",
         "firecrawlApiKey",
+        "firecrawlBaseUrl",
         "systemPrompt",
       ]);
     });
@@ -59,12 +61,26 @@ describe("chrome_storage", () => {
         openaiApiKey: "sk-test123",
         openaiModel: "gpt-4",
         slackWebhookUrl: "https://hooks.slack.com/services/test",
+        firecrawlApiKey: "fc-test123",
+        firecrawlBaseUrl: "http://localhost:3002",
       };
       mockChromeStorage.local.get.mockResolvedValue(storedSettings);
 
       const result = await getSettings();
 
       expect(result).toEqual(storedSettings);
+    });
+
+    it("Firecrawl Base URLが存在しない場合は既定値を返す", async () => {
+      const storedSettings = {
+        daysUntilRead: 10,
+        daysUntilDelete: 20,
+      };
+      mockChromeStorage.local.get.mockResolvedValue(storedSettings);
+
+      const result = await getSettings();
+
+      expect(result.firecrawlBaseUrl).toBe(DEFAULT_FIRECRAWL_BASE_URL);
     });
 
     it("エラーが発生した場合はデフォルト設定を返す", async () => {
@@ -114,6 +130,7 @@ describe("chrome_storage", () => {
         openaiModel: "gpt-4",
         slackWebhookUrl: "https://hooks.slack.com/services/test",
         firecrawlApiKey: "fc-test123",
+        firecrawlBaseUrl: "http://localhost:3002",
         systemPrompt: "カスタムプロンプト",
       };
 
@@ -129,6 +146,7 @@ describe("chrome_storage", () => {
         openaiModel: "gpt-4",
         slackWebhookUrl: "https://hooks.slack.com/services/test",
         firecrawlApiKey: "fc-test123",
+        firecrawlBaseUrl: "http://localhost:3002",
         systemPrompt: "カスタムプロンプト",
       });
     });
@@ -144,6 +162,7 @@ describe("chrome_storage", () => {
         openaiModel: "",
         slackWebhookUrl: "",
         firecrawlApiKey: "",
+        firecrawlBaseUrl: "",
         systemPrompt: "",
       };
 
@@ -186,6 +205,7 @@ describe("chrome_storage", () => {
         alarmIntervalMinutes: 720,
         openaiEndpoint: "https://api.openai.com/v1",
         slackWebhookUrl: "https://hooks.slack.com/services/test",
+        firecrawlBaseUrl: "https://api.firecrawl.dev",
       };
 
       const errors = validateSettings(settings);
@@ -252,6 +272,26 @@ describe("chrome_storage", () => {
       });
       expect(errors2).toContain(
         "Slack Webhook URLはSlackの正しいURLで入力してください",
+      );
+    });
+
+    it("無効なFirecrawl Base URLの場合はエラーを返す", () => {
+      const errors = validateSettings({
+        firecrawlBaseUrl: "not-a-url",
+      });
+
+      expect(errors).toContain(
+        "Firecrawl Base URLは有効なURLで入力してください",
+      );
+    });
+
+    it("Firecrawl Base URLがhttp/https以外の場合はエラーを返す", () => {
+      const errors = validateSettings({
+        firecrawlBaseUrl: "ftp://example.com",
+      });
+
+      expect(errors).toContain(
+        "Firecrawl Base URLはhttpまたはhttpsで指定してください",
       );
     });
 


### PR DESCRIPTION
fix: #46 AIによる自動PR

## 実装内容
- Firecrawl Base URL を設定スキーマに追加し、デフォルト値とバリデーションを付与
- 本文抽出処理で設定済みの Base URL を利用しつつ、無効値はデフォルトへフォールバック
- オプション画面と README を更新して Base URL の編集方法とセルフホスト利用可否を案内
- 関連テストを更新・追加し、`pnpm check:ai` で検証

## 参考・注意点
- Base URL は `src/common/constants.ts` に集約しています

## 質問・懸念点
- 特になし
