### PR TITLE
Add Tavily content extraction provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ReadingListAutoSummaryは、Chromeの標準リーディングリスト機能（`
 
 - **要約生成・Slack投稿**  
   - 既読化のタイミングで、エントリの「タイトル」「URL」「本文」を要約
-  - 本文はFirecrawl（[公式JS SDK](https://docs.firecrawl.dev/sdks/node)）で抽出
+  - 本文はTavily Extract APIもしくはFirecrawlのScrape APIから抽出（オプション画面で切り替え可能）
   - LLM（OpenAI SDK/OpenAI互換API）で3文・600文字以内に要約
   - 要約結果をSlack Webhook URL経由で自動投稿
 
@@ -30,7 +30,10 @@ ReadingListAutoSummaryは、Chromeの標準リーディングリスト機能（`
     - APIキー
     - モデル名
     - Slack Webhook URL
-    - Firecrawl Base URL（デフォルト: https://api.firecrawl.dev）
+  - コンテンツ抽出プロバイダー（Tavily / Firecrawl）
+  - Tavily API キー
+  - Firecrawl API キー
+  - Firecrawl Base URL（デフォルト: https://api.firecrawl.dev）
 
 - **ユーザーインターフェース**  
   - 基本的にUIは不要
@@ -42,7 +45,7 @@ ReadingListAutoSummaryは、Chromeの標準リーディングリスト機能（`
 1. **定期処理（バックグラウンドスクリプト）**
     - Chromeリーディングリストからエントリ取得
     - 未読エントリの登録日時をチェックし、規定日数経過で既読化
-    - 既読化時に本文をFirecrawl SDKで抽出
+    - 既読化時に選択中のコンテンツ抽出プロバイダーから本文を取得
     - 本文・タイトル・URLをOpenAI互換APIで要約（3文・600文字以内）
     - Slack Webhookへ指定フォーマットで投稿
     - 既読エントリの既読化日時をチェックし、規定日数経過で自動削除
@@ -72,15 +75,16 @@ ReadingListAutoSummaryは、Chromeの標準リーディングリスト機能（`
 
 - Chrome拡張（Manifest V3）
 - chrome.readingList API
-- Firecrawl JS SDK（本文抽出）
+- Tavily Extract API / Firecrawl Scrape API（本文抽出）
 - OpenAI SDK（OpenAI互換API対応）
 - Slack Webhook
 - chrome.storage.local（設定保存）
 
-## Firecrawlの利用
+## コンテンツ抽出プロバイダー
 
-- 既定のBase URLは `https://api.firecrawl.dev` です。オプション画面で Base URL を変更すれば、`http://localhost:3002` などセルフホストした Firecrawl サーバーにも接続できます。
-- セルフホスト環境では `Authorization` ヘッダーの値に任意の文字列を指定できますが、フォームには空でない値を入力してください。
+- デフォルトは Tavily Extract API（Base URL: `https://api.tavily.com`）です。無料枠でも毎月1,000件まで抽出可能です。
+- Firecrawlを利用する場合は、プロバイダーを Firecrawl に切り替え、APIキーと必要に応じて Base URL を設定してください。Base URL を変更すれば、`http://localhost:3002` などセルフホストした Firecrawl サーバーにも接続できます。
+- どちらのプロバイダーでも本文抽出に失敗した場合は自動的にリトライし、最終的に失敗した際はSlackへエラー通知を送信します。
 
 ## 今後の拡張予定
 

--- a/src/backend/background.ts
+++ b/src/backend/background.ts
@@ -4,13 +4,23 @@ import {
   getSettings,
   type Settings,
 } from "../common/chrome_storage";
-import { DEFAULT_FIRECRAWL_BASE_URL } from "../common/constants";
+import {
+  type ContentExtractorProvider,
+  DEFAULT_CONTENT_EXTRACTOR_PROVIDER,
+  DEFAULT_FIRECRAWL_BASE_URL,
+} from "../common/constants";
 import type {
   FrontendMessage,
   ManualExecuteResult,
   SlackTestResult,
 } from "../types/messages";
-import { type ExtractContentResult, extractContent } from "./content_extractor";
+import {
+  type ExtractContentConfig,
+  type ExtractContentResult,
+  extractContent,
+  type FirecrawlConfig,
+  type TavilyConfig,
+} from "./content_extractor";
 import { postToSlack } from "./post";
 import {
   formatSlackErrorMessage,
@@ -112,19 +122,20 @@ async function handleExtractContentMessage(
   try {
     const settings = await getSettings();
 
-    if (!settings.firecrawlApiKey) {
+    const provider = resolveContentExtractorProvider(settings);
+    const missingKeyError = validateContentExtractorCredentials(
+      provider,
+      settings,
+    );
+
+    if (missingKeyError) {
       return {
         success: false,
-        error:
-          "Firecrawl API キーが設定されていません。設定を保存してからお試しください。",
+        error: missingKeyError,
       };
     }
 
-    return await extractContent(
-      url,
-      settings.firecrawlApiKey,
-      settings.firecrawlBaseUrl || DEFAULT_FIRECRAWL_BASE_URL,
-    );
+    return await extractContent(url, buildExtractorConfig(settings));
   } catch (error) {
     return {
       success: false,
@@ -282,22 +293,28 @@ async function processContentExtraction(
   entry: chrome.readingList.ReadingListEntry,
   settings: Settings,
 ): Promise<void> {
-  if (!settings.firecrawlApiKey) {
+  const provider = resolveContentExtractorProvider(settings);
+  const missingKeyError = validateContentExtractorCredentials(
+    provider,
+    settings,
+  );
+
+  if (missingKeyError) {
     console.error(
-      `Firecrawl API キーが未設定のため、本文抽出をスキップ: ${entry.title}`,
+      `${provider} API キーが未設定のため本文抽出をスキップ: ${entry.title}`,
     );
+    await notifyExtractionError(entry, settings, provider, missingKeyError);
     return;
   }
 
   const extractResult = await extractContent(
     entry.url,
-    settings.firecrawlApiKey,
-    settings.firecrawlBaseUrl || DEFAULT_FIRECRAWL_BASE_URL,
+    buildExtractorConfig(settings),
   );
 
   if (!extractResult.success || !extractResult.content) {
     console.error(`本文抽出失敗: ${entry.title} - ${extractResult.error}`);
-    await notifyExtractionError(entry, settings, extractResult.error);
+    await notifyExtractionError(entry, settings, provider, extractResult.error);
     return;
   }
 
@@ -366,6 +383,7 @@ async function processSummarization(
 async function notifyExtractionError(
   entry: chrome.readingList.ReadingListEntry,
   settings: Settings,
+  provider: ContentExtractorProvider,
   error?: string,
 ): Promise<void> {
   if (!settings.slackWebhookUrl || !settings.openaiModel) {
@@ -376,9 +394,55 @@ async function notifyExtractionError(
     entry.title,
     entry.url,
     settings.openaiModel,
-    `本文抽出失敗: ${error}`,
+    `本文抽出失敗 (${provider}): ${error}`,
   );
   await postToSlack(settings.slackWebhookUrl, errorMessage);
+}
+
+function resolveContentExtractorProvider(
+  settings: Settings,
+): ContentExtractorProvider {
+  return (
+    settings.contentExtractorProvider || DEFAULT_CONTENT_EXTRACTOR_PROVIDER
+  );
+}
+
+function buildExtractorConfig(settings: Settings): ExtractContentConfig {
+  const firecrawlOptions: FirecrawlConfig = {
+    baseUrl: settings.firecrawlBaseUrl || DEFAULT_FIRECRAWL_BASE_URL,
+  };
+  if (settings.firecrawlApiKey !== undefined) {
+    firecrawlOptions.apiKey = settings.firecrawlApiKey;
+  }
+
+  const tavilyOptions: TavilyConfig = {};
+  if (settings.tavilyApiKey !== undefined) {
+    tavilyOptions.apiKey = settings.tavilyApiKey;
+  }
+
+  return {
+    provider: resolveContentExtractorProvider(settings),
+    firecrawl: firecrawlOptions,
+    tavily: tavilyOptions,
+  };
+}
+
+function validateContentExtractorCredentials(
+  provider: ContentExtractorProvider,
+  settings: Settings,
+): string | null {
+  if (provider === "tavily") {
+    if (!settings.tavilyApiKey?.trim()) {
+      return "Tavily API キーが設定されていません。設定を保存してからお試しください。";
+    }
+    return null;
+  }
+
+  if (!settings.firecrawlApiKey?.trim()) {
+    return "Firecrawl API キーが設定されていません。設定を保存してからお試しください。";
+  }
+
+  return null;
 }
 
 /**

--- a/src/backend/content_extractor.ts
+++ b/src/backend/content_extractor.ts
@@ -1,10 +1,29 @@
-import { DEFAULT_FIRECRAWL_BASE_URL } from "../common/constants";
+import {
+  type ContentExtractorProvider,
+  DEFAULT_FIRECRAWL_BASE_URL,
+  DEFAULT_TAVILY_BASE_URL,
+} from "../common/constants";
 
 export interface ExtractContentResult {
   success: boolean;
   content?: string;
   title?: string;
   error?: string;
+}
+
+export interface FirecrawlConfig {
+  apiKey?: string;
+  baseUrl?: string;
+}
+
+export interface TavilyConfig {
+  apiKey?: string;
+}
+
+export interface ExtractContentConfig {
+  provider: ContentExtractorProvider;
+  firecrawl?: FirecrawlConfig;
+  tavily?: TavilyConfig;
 }
 
 interface FirecrawlV2Metadata {
@@ -25,6 +44,21 @@ interface FirecrawlV2Response {
   success: boolean;
   data?: FirecrawlV2Data;
   warning?: string;
+}
+
+interface TavilyExtractResult {
+  url: string;
+  raw_content?: string;
+  title?: string;
+  favicon?: string;
+}
+
+interface TavilyExtractResponse {
+  results?: TavilyExtractResult[];
+  failed_results?: Array<{
+    url: string;
+    error: string;
+  }>;
 }
 
 /**
@@ -66,68 +100,21 @@ async function retryWithExponentialBackoff<T>(
  */
 export async function extractContent(
   url: string,
-  apiKey: string,
-  firecrawlBaseUrl: string = DEFAULT_FIRECRAWL_BASE_URL,
+  config: ExtractContentConfig,
 ): Promise<ExtractContentResult> {
-  if (!apiKey?.trim()) {
-    const error = "Firecrawl API キーが設定されていません";
-    console.error(error);
-    return {
-      success: false,
-      error,
-    };
-  }
-
-  console.log(`本文抽出開始: ${url}`);
+  console.log(`本文抽出開始: ${url} (provider=${config.provider})`);
 
   try {
     const result = await retryWithExponentialBackoff(async () => {
-      console.log(`Firecrawl API呼び出し: ${url}`);
-
-      const sanitizedBaseUrl =
-        firecrawlBaseUrl?.trim() || DEFAULT_FIRECRAWL_BASE_URL;
-      let endpoint: string;
-
-      try {
-        endpoint = new URL("/v2/scrape", sanitizedBaseUrl).toString();
-      } catch (error) {
-        console.warn(
-          `Firecrawl Base URLの解析に失敗したためデフォルトを使用します: ${sanitizedBaseUrl}`,
-          error,
-        );
-        endpoint = new URL("/v2/scrape", DEFAULT_FIRECRAWL_BASE_URL).toString();
+      if (config.provider === "firecrawl") {
+        return extractWithFirecrawl(url, config.firecrawl);
       }
 
-      const response = await fetch(endpoint, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          url,
-          formats: ["markdown"],
-          onlyMainContent: true,
-        }),
-      });
-
-      if (!response.ok) {
-        throw new Error(
-          `Firecrawl API error: ${response.status} ${response.statusText}`,
-        );
+      if (config.provider === "tavily") {
+        return extractWithTavily(url, config.tavily);
       }
 
-      const apiResponse: FirecrawlV2Response = await response.json();
-
-      // エラーレスポンスの場合
-      if (!apiResponse || !apiResponse.data || !apiResponse.data.markdown) {
-        throw new Error("抽出された本文が空です");
-      }
-
-      return {
-        content: apiResponse.data.markdown,
-        title: apiResponse.data.metadata?.title || new URL(url).hostname,
-      };
+      throw new Error(`未対応のプロバイダーです: ${config.provider}`);
     });
 
     console.log(`本文抽出成功: ${url} (文字数: ${result.content.length})`);
@@ -138,10 +125,120 @@ export async function extractContent(
     };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
-    console.error(`本文抽出失敗: ${url} - ${errorMessage}`);
+    console.error(
+      `本文抽出失敗: ${url} (provider=${config.provider}) - ${errorMessage}`,
+    );
     return {
       success: false,
       error: errorMessage,
     };
   }
+}
+
+async function extractWithFirecrawl(
+  url: string,
+  config: FirecrawlConfig | undefined,
+): Promise<{ content: string; title: string }> {
+  const apiKey = config?.apiKey?.trim();
+  if (!apiKey) {
+    throw new Error("Firecrawl API キーが設定されていません");
+  }
+
+  console.log(`Firecrawl API呼び出し: ${url}`);
+
+  const sanitizedBaseUrl =
+    config?.baseUrl?.trim() || DEFAULT_FIRECRAWL_BASE_URL;
+  let endpoint: string;
+
+  try {
+    endpoint = new URL("/v2/scrape", sanitizedBaseUrl).toString();
+  } catch (error) {
+    console.warn(
+      `Firecrawl Base URLの解析に失敗したためデフォルトを使用します: ${sanitizedBaseUrl}`,
+      error,
+    );
+    endpoint = new URL("/v2/scrape", DEFAULT_FIRECRAWL_BASE_URL).toString();
+  }
+
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      url,
+      formats: ["markdown"],
+      onlyMainContent: true,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Firecrawl API error: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const apiResponse: FirecrawlV2Response = await response.json();
+
+  if (!apiResponse?.data?.markdown) {
+    throw new Error("抽出された本文が空です");
+  }
+
+  return {
+    content: apiResponse.data.markdown,
+    title: apiResponse.data.metadata?.title || new URL(url).hostname,
+  };
+}
+
+async function extractWithTavily(
+  url: string,
+  config: TavilyConfig | undefined,
+): Promise<{ content: string; title: string }> {
+  const apiKey = config?.apiKey?.trim();
+  if (!apiKey) {
+    throw new Error("Tavily API キーが設定されていません");
+  }
+
+  console.log(`Tavily API呼び出し: ${url}`);
+
+  let endpoint: string;
+  try {
+    endpoint = new URL("/extract", DEFAULT_TAVILY_BASE_URL).toString();
+  } catch (error) {
+    console.warn("Tavily APIエンドポイントの解析に失敗しました", error);
+    endpoint = `${DEFAULT_TAVILY_BASE_URL}/extract`;
+  }
+
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      urls: [url],
+      extract_depth: "basic",
+      format: "markdown",
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Tavily API error: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const apiResponse: TavilyExtractResponse = await response.json();
+
+  const result = apiResponse?.results?.[0];
+  if (!result?.raw_content) {
+    const failedMessage = apiResponse?.failed_results?.[0]?.error;
+    throw new Error(failedMessage || "抽出された本文が空です");
+  }
+
+  return {
+    content: result.raw_content,
+    title: result.title || new URL(url).hostname,
+  };
 }

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,1 +1,11 @@
 export const DEFAULT_FIRECRAWL_BASE_URL = "https://api.firecrawl.dev";
+
+export const DEFAULT_TAVILY_BASE_URL = "https://api.tavily.com";
+
+export const CONTENT_EXTRACTOR_PROVIDERS = ["tavily", "firecrawl"] as const;
+
+export type ContentExtractorProvider =
+  (typeof CONTENT_EXTRACTOR_PROVIDERS)[number];
+
+export const DEFAULT_CONTENT_EXTRACTOR_PROVIDER: ContentExtractorProvider =
+  "tavily";

--- a/src/frontend/options/ContentExtractorTest.tsx
+++ b/src/frontend/options/ContentExtractorTest.tsx
@@ -1,6 +1,7 @@
 import { useState } from "preact/hooks";
 import type { ExtractContentResult } from "../../backend/content_extractor";
 import type { SummarizeResult } from "../../backend/summarizer";
+import type { ContentExtractorProvider } from "../../common/constants";
 import type {
   ExtractContentMessage,
   SlackTestMessage,
@@ -55,7 +56,11 @@ function isSlackTestResult(obj: unknown): obj is SlackTestResult {
   );
 }
 
-export function ContentExtractorTest() {
+interface ContentExtractorTestProps {
+  provider: ContentExtractorProvider;
+}
+
+export function ContentExtractorTest({ provider }: ContentExtractorTestProps) {
   const [url, setUrl] = useState("");
   const [isProcessing, setIsProcessing] = useState(false);
   const [result, setResult] = useState<ExtractContentResult | null>(null);
@@ -196,7 +201,12 @@ export function ContentExtractorTest() {
 
   return (
     <section class="bg-gray-50 p-4 rounded-lg">
-      <h3 class="text-md font-semibold mb-4">コンテンツ抽出テスト</h3>
+      <div class="flex items-center justify-between mb-4">
+        <h3 class="text-md font-semibold">コンテンツ抽出テスト</h3>
+        <span class="text-xs font-medium text-gray-600 border border-gray-300 rounded px-2 py-1">
+          現在のプロバイダー: {provider === "tavily" ? "Tavily" : "Firecrawl"}
+        </span>
+      </div>
 
       <div class="space-y-4">
         <div>

--- a/tests/backend/background.test.ts
+++ b/tests/backend/background.test.ts
@@ -11,7 +11,10 @@ import {
   DELETION_DISABLED_VALUE,
   getSettings,
 } from "../../src/common/chrome_storage";
-import { DEFAULT_FIRECRAWL_BASE_URL } from "../../src/common/constants";
+import {
+  DEFAULT_CONTENT_EXTRACTOR_PROVIDER,
+  DEFAULT_FIRECRAWL_BASE_URL,
+} from "../../src/common/constants";
 
 // content_extractor モジュールのモック
 vi.mock("../../src/backend/content_extractor", () => ({
@@ -78,6 +81,7 @@ describe("getSettings", () => {
       daysUntilDelete: DELETION_DISABLED_VALUE,
       maxEntriesPerRun: 3,
       alarmIntervalMinutes: 720,
+      contentExtractorProvider: DEFAULT_CONTENT_EXTRACTOR_PROVIDER,
       firecrawlBaseUrl: DEFAULT_FIRECRAWL_BASE_URL,
     });
     expect(mockChromeStorageLocal.get).toHaveBeenCalledWith([
@@ -89,6 +93,8 @@ describe("getSettings", () => {
       "openaiApiKey",
       "openaiModel",
       "slackWebhookUrl",
+      "contentExtractorProvider",
+      "tavilyApiKey",
       "firecrawlApiKey",
       "firecrawlBaseUrl",
       "systemPrompt",
@@ -105,6 +111,7 @@ describe("getSettings", () => {
       openaiApiKey: "test-key",
       openaiModel: "gpt-3.5-turbo",
       slackWebhookUrl: "https://hooks.slack.com/test",
+      contentExtractorProvider: "firecrawl" as const,
       firecrawlApiKey: "fc-test-key",
       firecrawlBaseUrl: "http://localhost:3002",
       systemPrompt: "カスタムプロンプト",
@@ -126,6 +133,7 @@ describe("getSettings", () => {
       daysUntilDelete: DELETION_DISABLED_VALUE,
       maxEntriesPerRun: 3,
       alarmIntervalMinutes: 720,
+      contentExtractorProvider: DEFAULT_CONTENT_EXTRACTOR_PROVIDER,
       firecrawlBaseUrl: DEFAULT_FIRECRAWL_BASE_URL,
     });
   });
@@ -304,6 +312,7 @@ describe("markAsReadAndNotify", () => {
     openaiApiKey: "test-key",
     openaiModel: "gpt-4o-mini",
     slackWebhookUrl: "https://hooks.slack.com/test",
+    contentExtractorProvider: "firecrawl" as const,
     firecrawlApiKey: "fc-test-key",
     firecrawlBaseUrl: DEFAULT_FIRECRAWL_BASE_URL,
   };
@@ -333,6 +342,7 @@ describe("markAsReadAndNotify", () => {
     const incompleteSettings = {
       daysUntilRead: 30,
       daysUntilDelete: 60,
+      contentExtractorProvider: "firecrawl" as const,
       firecrawlApiKey: "fc-test-key",
     };
 
@@ -342,11 +352,16 @@ describe("markAsReadAndNotify", () => {
       url: entry.url,
       hasBeenRead: true,
     });
-    expect(mockExtractContent).toHaveBeenCalledWith(
-      entry.url,
-      incompleteSettings.firecrawlApiKey,
-      DEFAULT_FIRECRAWL_BASE_URL,
-    );
+    expect(mockExtractContent).toHaveBeenCalledWith(entry.url, {
+      provider: "firecrawl",
+      firecrawl: {
+        apiKey: "fc-test-key",
+        baseUrl: DEFAULT_FIRECRAWL_BASE_URL,
+      },
+      tavily: {
+        apiKey: undefined,
+      },
+    });
     // 要約機能は呼ばれない
     expect(mockSummarizeContent).not.toHaveBeenCalled();
     expect(mockPostToSlack).not.toHaveBeenCalled();
@@ -495,6 +510,7 @@ describe("markAsReadAndNotify", () => {
       openaiApiKey: "test-key",
       openaiModel: "gpt-4o-mini",
       slackWebhookUrl: "https://hooks.slack.com/test",
+      contentExtractorProvider: "firecrawl" as const,
       // firecrawlApiKey が未設定
     };
 
@@ -505,6 +521,40 @@ describe("markAsReadAndNotify", () => {
     expect(mockExtractContent).not.toHaveBeenCalled();
     expect(mockSummarizeContent).not.toHaveBeenCalled();
     expect(mockPostToSlack).not.toHaveBeenCalled();
+  });
+
+  it("Tavily API キーが未設定の場合にSlackへエラー通知を送る", async () => {
+    const entry = {
+      url: "https://example.com",
+      title: "テスト記事",
+      hasBeenRead: false,
+      creationTime: Date.now() - 35 * 24 * 60 * 60 * 1000,
+      lastUpdateTime: Date.now() - 35 * 24 * 60 * 60 * 1000,
+    };
+
+    const settingsWithoutTavily = {
+      daysUntilRead: 30,
+      daysUntilDelete: 60,
+      contentExtractorProvider: "tavily" as const,
+      openaiModel: "gpt-4o-mini",
+      slackWebhookUrl: "https://hooks.slack.com/test",
+    };
+
+    mockChromeReadingList.updateEntry.mockResolvedValue(undefined);
+
+    await markAsReadAndNotify(entry, settingsWithoutTavily);
+
+    expect(mockExtractContent).not.toHaveBeenCalled();
+    expect(mockFormatSlackErrorMessage).toHaveBeenCalledWith(
+      entry.title,
+      entry.url,
+      settingsWithoutTavily.openaiModel,
+      expect.stringContaining("Tavily"),
+    );
+    expect(mockPostToSlack).toHaveBeenCalledWith(
+      settingsWithoutTavily.slackWebhookUrl,
+      expect.any(String),
+    );
   });
 
   it("既読化APIエラー時に例外をスロー", async () => {
@@ -567,6 +617,9 @@ describe("processReadingListEntries", () => {
     daysUntilRead: 30,
     daysUntilDelete: 60,
     maxEntriesPerRun: 3,
+    contentExtractorProvider: "firecrawl" as const,
+    firecrawlApiKey: "fc-test-key",
+    firecrawlBaseUrl: DEFAULT_FIRECRAWL_BASE_URL,
   };
 
   it("統合処理：設定取得、エントリ取得、フィルタリング、処理実行", async () => {
@@ -701,6 +754,9 @@ describe("processReadingListEntries", () => {
       daysUntilRead: 30,
       daysUntilDelete: 60,
       maxEntriesPerRun: 3,
+      contentExtractorProvider: "firecrawl" as const,
+      firecrawlApiKey: "fc-test-key",
+      firecrawlBaseUrl: DEFAULT_FIRECRAWL_BASE_URL,
     };
 
     mockChromeStorageLocal.get.mockResolvedValue(settingsWithLimit);

--- a/tests/backend/message_handling.test.ts
+++ b/tests/backend/message_handling.test.ts
@@ -76,6 +76,7 @@ describe("Message handling", () => {
     vi.useFakeTimers();
     // 設定のモック
     mockChromeStorageLocal.get.mockResolvedValue({
+      contentExtractorProvider: "firecrawl" as const,
       firecrawlApiKey: "fc-test-key",
       firecrawlBaseUrl: "http://localhost:3002",
     });
@@ -111,11 +112,16 @@ describe("Message handling", () => {
       await vi.runAllTimersAsync();
 
       // extractContent が正しい引数で呼ばれることを確認
-      expect(mockExtractContent).toHaveBeenCalledWith(
-        "https://example.com",
-        "fc-test-key",
-        "http://localhost:3002",
-      );
+      expect(mockExtractContent).toHaveBeenCalledWith("https://example.com", {
+        provider: "firecrawl",
+        firecrawl: {
+          apiKey: "fc-test-key",
+          baseUrl: "http://localhost:3002",
+        },
+        tavily: {
+          apiKey: undefined,
+        },
+      });
 
       // sendResponse が正しい結果で呼ばれることを確認
       expect(sendResponse).toHaveBeenCalledWith(mockResult);
@@ -125,8 +131,11 @@ describe("Message handling", () => {
 
   it("Firecrawl API キーが未設定の場合はエラーを返す", async () => {
     vi.useFakeTimers();
-    // 設定のモック（API キーなし）
-    mockChromeStorageLocal.get.mockResolvedValue({});
+    // 設定のモック（Firecrawl選択だがAPI キーなし）
+    mockChromeStorageLocal.get.mockResolvedValue({
+      contentExtractorProvider: "firecrawl" as const,
+      firecrawlBaseUrl: DEFAULT_FIRECRAWL_BASE_URL,
+    });
 
     const sendResponse = vi.fn();
     const request = {
@@ -157,10 +166,40 @@ describe("Message handling", () => {
     vi.useRealTimers();
   });
 
+  it("Tavily API キーが未設定の場合はエラーを返す", async () => {
+    vi.useFakeTimers();
+    mockChromeStorageLocal.get.mockResolvedValue({});
+
+    const sendResponse = vi.fn();
+    const request = {
+      type: "EXTRACT_CONTENT",
+      url: "https://example.com",
+    };
+
+    if (messageListener) {
+      messageListener(
+        request,
+        {} as chrome.runtime.MessageSender,
+        sendResponse,
+      );
+
+      await vi.runAllTimersAsync();
+
+      expect(mockExtractContent).not.toHaveBeenCalled();
+      expect(sendResponse).toHaveBeenCalledWith({
+        success: false,
+        error:
+          "Tavily API キーが設定されていません。設定を保存してからお試しください。",
+      });
+    }
+    vi.useRealTimers();
+  });
+
   it("extractContent でエラーが発生した場合はエラーを返す", async () => {
     vi.useFakeTimers();
     // 設定のモック
     mockChromeStorageLocal.get.mockResolvedValue({
+      contentExtractorProvider: "firecrawl" as const,
       firecrawlApiKey: "fc-test-key",
       firecrawlBaseUrl: DEFAULT_FIRECRAWL_BASE_URL,
     });


### PR DESCRIPTION
fix: #45 AIによる自動PR

## 実装内容
- 設定スキーマと共通定数にコンテンツ抽出プロバイダー（Tavily / Firecrawl）を追加し、プロバイダー別のAPIキー検証を実装
- Firecrawl/Tavily両対応の本文抽出ファサードを新設し、サービスワーカーやSlack通知処理から利用するよう更新
- オプション画面にプロバイダー切り替えUIとタブ別設定フォームを追加し、テストUIにも選択中プロバイダーを表示
- READMEおよび各種テストをTavily追加仕様に合わせて更新

## 参考・注意点
- Tavily Extract APIの `extract` エンドポイント仕様（https://docs.tavily.com/documentation/api-reference/endpoint/extract）を参考に実装しました
- サンドボックス環境の制約によりVitest実行時に `ERR_IPC_CHANNEL_CLOSED` が発生するため、`threads: false` で単一プロセス実行に切り替えています

## テスト
- `pnpm type-check`
- `pnpm biome:fix`
- `pnpm test --run --reporter=dot` （ERR_IPC_CHANNEL_CLOSED のため失敗）
- `pnpm build`
