### PR TITLE
PDFのローカル抽出機能を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@mizchi/readability": "^0.7.7",
     "openai": "^5.16.0",
-    "preact": "^10.27.3"
+    "preact": "^10.27.3",
+    "unpdf": "^1.6.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       preact:
         specifier: ^10.27.3
         version: 10.27.3
+      unpdf:
+        specifier: ^1.6.0
+        version: 1.6.0
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.2.2
@@ -180,24 +183,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.2.2':
     resolution: {integrity: sha512-JfrK3gdmWWTh2J5tq/rcWCOsImVyzUnOS2fkjhiYKCQ+v8PqM+du5cfB7G1kXas+7KQeKSWALv18iQqdtIMvzw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.2.2':
     resolution: {integrity: sha512-ZCLXcZvjZKSiRY/cFANKg+z6Fhsf9MHOzj+NrDQcM+LbqYRT97LyCLWy2AS+W2vP+i89RyRM+kbGpUzbRTYWig==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.2.2':
     resolution: {integrity: sha512-Ogb+77edO5LEP/xbNicACOWVLt8mgC+E1wmpUakr+O4nKwLt9vXe74YNuT3T1dUBxC/SnrVmlzZFC7kQJEfquQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.2.2':
     resolution: {integrity: sha512-wBe2wItayw1zvtXysmHJQoQqXlTzHSpQRyPpJKiNIR21HzH/CrZRDFic1C1jDdp+zAPtqhNExa0owKMbNwW9cQ==}
@@ -509,66 +516,79 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -638,24 +658,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.12':
     resolution: {integrity: sha512-V8pAM3s8gsrXcCv6kCHSuwyb/gPsd863iT+v1PGXC4fSL/OJqsKhfK//v8P+w9ThKIoqNbEnsZqNy+WDnwQqCA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.12':
     resolution: {integrity: sha512-xYfqYLjvm2UQ3TZggTGrwxjYaLB62b1Wiysw/YE3Yqbh86sOMoTn0feF98PonP7LtjsWOWcXEbGqDL7zv0uW8Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.12':
     resolution: {integrity: sha512-ha0pHPamN+fWZY7GCzz5rKunlv9L5R8kdh+YNvP5awe3LtuXb5nRi/H27GeL2U+TdhDOptU7T6Is7mdwh5Ar3A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.12':
     resolution: {integrity: sha512-4tSyu3dW+ktzdEpuk6g49KdEangu3eCYoqPhWNsZgUhyegEda3M9rG0/j1GV/JjVVsj+lG7jWAyrTlLzd/WEBg==}
@@ -1269,24 +1293,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
@@ -1672,6 +1700,14 @@ packages:
 
   undici-types@7.10.0:
     resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
+
+  unpdf@1.6.0:
+    resolution: {integrity: sha512-DsjbuDe6PDbZzGvAP40QQp0xskrXP3Tm3fd/FLkGObL00Icr7cc28QgrPHYg+6B1lMWydgXwDXauIv5CGyXudA==}
+    peerDependencies:
+      '@napi-rs/canvas': ^0.1.69
+    peerDependenciesMeta:
+      '@napi-rs/canvas':
+        optional: true
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -3387,6 +3423,8 @@ snapshots:
   typescript@5.9.2: {}
 
   undici-types@7.10.0: {}
+
+  unpdf@1.6.0: {}
 
   unpipe@1.0.0: {}
 

--- a/scripts/validate-unpdf.mjs
+++ b/scripts/validate-unpdf.mjs
@@ -1,4 +1,32 @@
+import { createRequire } from "node:module";
 import { extractText, getDocumentProxy, getMeta } from "unpdf";
+
+const require = createRequire(import.meta.url);
+
+function normalizeError(error) {
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      stack: error.stack,
+    };
+  }
+
+  return {
+    message: String(error),
+    stack: undefined,
+  };
+}
+
+function getUnpdfVersion() {
+  try {
+    const packageJson = require("unpdf/package.json");
+    return typeof packageJson.version === "string"
+      ? packageJson.version
+      : "unknown";
+  } catch {
+    return "unknown";
+  }
+}
 
 const PDFS = [
   {
@@ -57,7 +85,9 @@ async function validatePdf(pdfConfig) {
         );
       }
     } catch (metaError) {
-      console.log(`   Metadata extraction failed: ${metaError.message}`);
+      console.log(
+        `   Metadata extraction failed: ${normalizeError(metaError).message}`,
+      );
     }
 
     // Extract text (per-page)
@@ -72,8 +102,7 @@ async function validatePdf(pdfConfig) {
     console.log(`   Total characters: ${totalChars.toLocaleString()}`);
 
     // Per-page stats
-    for (let i = 0; i < result.text.length; i++) {
-      const pageText = result.text[i];
+    for (const [i, pageText] of result.text.entries()) {
       console.log(
         `   Page ${i + 1}: ${pageText.length.toLocaleString()} chars`,
       );
@@ -113,18 +142,19 @@ async function validatePdf(pdfConfig) {
 
     return { success: true, totalChars, pages: result.totalPages };
   } catch (error) {
-    console.log(`\n   ❌ ERROR: ${error.message}`);
-    console.log(
-      `   Stack: ${error.stack?.split("\n").slice(0, 3).join("\n         ")}`,
-    );
-    return { success: false, error: error.message };
+    const normalizedError = normalizeError(error);
+    console.log(`\n   ❌ ERROR: ${normalizedError.message}`);
+    if (normalizedError.stack) {
+      console.log(
+        `   Stack: ${normalizedError.stack.split("\n").slice(0, 3).join("\n         ")}`,
+      );
+    }
+    return { success: false, error: normalizedError.message };
   }
 }
 
 console.log("🔍 unpdf Validation Script");
-console.log(
-  `   unpdf version: ${await import("unpdf/package.json").then((m) => m.default.version).catch(() => "unknown")}`,
-);
+console.log(`   unpdf version: ${getUnpdfVersion()}`);
 
 const results = [];
 for (const pdf of PDFS) {

--- a/scripts/validate-unpdf.mjs
+++ b/scripts/validate-unpdf.mjs
@@ -1,0 +1,146 @@
+import { extractText, getDocumentProxy, getMeta } from "unpdf";
+
+const PDFS = [
+  {
+    name: "Google Prompt Engineering Whitepaper",
+    url: "https://services.google.com/fh/files/misc/promptengineeringwhitepaper.pdf",
+  },
+  {
+    name: "DeNA AI 100 Tips Slide",
+    url: "https://fullswing.dena.com/pdf/AI_100tips_slide.pdf",
+  },
+];
+
+async function fetchPdf(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+  }
+  return await response.arrayBuffer();
+}
+
+async function validatePdf(pdfConfig) {
+  console.log(`\n${"=".repeat(70)}`);
+  console.log(`📄 ${pdfConfig.name}`);
+  console.log(`   URL: ${pdfConfig.url}`);
+  console.log(`${"=".repeat(70)}`);
+
+  try {
+    console.log("   Downloading PDF...");
+    const arrayBuffer = await fetchPdf(pdfConfig.url);
+    console.log(
+      `   Downloaded: ${(arrayBuffer.byteLength / 1024).toFixed(1)} KB`,
+    );
+
+    // Use getDocumentProxy to avoid ArrayBuffer detachment issues
+    // (passing raw ArrayBuffer to multiple functions detaches it)
+    const docProxy = await getDocumentProxy(arrayBuffer);
+
+    // Extract metadata
+    console.log("\n   --- Metadata ---");
+    try {
+      const meta = await getMeta(docProxy);
+      if (meta.info) {
+        const title = meta.info.Title || "(no title)";
+        const author = meta.info.Author || "(no author)";
+        const subject = meta.info.Subject || "(no subject)";
+        const creator = meta.info.Creator || "(no creator)";
+        console.log(`   Title:   ${title}`);
+        console.log(`   Author:  ${author}`);
+        console.log(`   Subject: ${subject}`);
+        console.log(`   Creator: ${creator}`);
+      }
+      if (meta.metadata) {
+        const metadataStr = String(meta.metadata);
+        console.log(
+          `   Raw metadata (first 200 chars): ${metadataStr.slice(0, 200)}`,
+        );
+      }
+    } catch (metaError) {
+      console.log(`   Metadata extraction failed: ${metaError.message}`);
+    }
+
+    // Extract text (per-page)
+    console.log("\n   --- Text Extraction (per-page) ---");
+    const result = await extractText(docProxy);
+    console.log(`   Total pages: ${result.totalPages}`);
+    console.log(`   Text chunks (pages): ${result.text.length}`);
+
+    // Combine all text for stats
+    const fullText = result.text.join("\n");
+    const totalChars = fullText.length;
+    console.log(`   Total characters: ${totalChars.toLocaleString()}`);
+
+    // Per-page stats
+    for (let i = 0; i < result.text.length; i++) {
+      const pageText = result.text[i];
+      console.log(
+        `   Page ${i + 1}: ${pageText.length.toLocaleString()} chars`,
+      );
+    }
+
+    // Show first 500 chars
+    console.log("\n   --- First 500 Characters ---");
+    const preview = fullText.slice(0, 500);
+    console.log(
+      preview
+        .split("\n")
+        .map((line) => `   | ${line}`)
+        .join("\n"),
+    );
+
+    // Quality assessment
+    console.log("\n   --- Quality Assessment ---");
+    const nonWhitespaceChars = fullText.replace(/\s/g, "").length;
+    const ratio = totalChars > 0 ? nonWhitespaceChars / totalChars : 0;
+    console.log(
+      `   Non-whitespace ratio: ${(ratio * 100).toFixed(1)}% (${nonWhitespaceChars.toLocaleString()} / ${totalChars.toLocaleString()})`,
+    );
+
+    // Check for common PDF extraction issues
+    const hasCharFragments = /[a-z]\s[a-z]\s[a-z]\s[a-z]/.test(fullText);
+    const avgWordLength =
+      fullText.split(/\s+/).filter(Boolean).length > 0
+        ? nonWhitespaceChars / fullText.split(/\s+/).filter(Boolean).length
+        : 0;
+    console.log(`   Average word length: ${avgWordLength.toFixed(1)}`);
+    console.log(
+      `   Character fragmentation detected: ${hasCharFragments ? "⚠️ YES" : "✅ No"}`,
+    );
+    console.log(
+      `   Sufficient for summarization: ${nonWhitespaceChars > 100 ? "✅ Yes" : "❌ No (too little text)"}`,
+    );
+
+    return { success: true, totalChars, pages: result.totalPages };
+  } catch (error) {
+    console.log(`\n   ❌ ERROR: ${error.message}`);
+    console.log(
+      `   Stack: ${error.stack?.split("\n").slice(0, 3).join("\n         ")}`,
+    );
+    return { success: false, error: error.message };
+  }
+}
+
+console.log("🔍 unpdf Validation Script");
+console.log(
+  `   unpdf version: ${await import("unpdf/package.json").then((m) => m.default.version).catch(() => "unknown")}`,
+);
+
+const results = [];
+for (const pdf of PDFS) {
+  const result = await validatePdf(pdf);
+  results.push({ name: pdf.name, ...result });
+}
+
+console.log(`\n${"=".repeat(70)}`);
+console.log("📊 Summary");
+console.log(`${"=".repeat(70)}`);
+for (const r of results) {
+  if (r.success) {
+    console.log(
+      `   ✅ ${r.name}: ${r.pages} pages, ${r.totalChars.toLocaleString()} chars`,
+    );
+  } else {
+    console.log(`   ❌ ${r.name}: ${r.error}`);
+  }
+}

--- a/scripts/validate-unpdf.mjs
+++ b/scripts/validate-unpdf.mjs
@@ -1,7 +1,4 @@
-import { createRequire } from "node:module";
-import { extractText, getDocumentProxy, getMeta } from "unpdf";
-
-const require = createRequire(import.meta.url);
+import { extractText, getDocumentProxy } from "unpdf";
 
 function normalizeError(error) {
   if (error instanceof Error) {
@@ -15,17 +12,6 @@ function normalizeError(error) {
     message: String(error),
     stack: undefined,
   };
-}
-
-function getUnpdfVersion() {
-  try {
-    const packageJson = require("unpdf/package.json");
-    return typeof packageJson.version === "string"
-      ? packageJson.version
-      : "unknown";
-  } catch {
-    return "unknown";
-  }
 }
 
 const PDFS = [
@@ -63,32 +49,6 @@ async function validatePdf(pdfConfig) {
     // Use getDocumentProxy to avoid ArrayBuffer detachment issues
     // (passing raw ArrayBuffer to multiple functions detaches it)
     const docProxy = await getDocumentProxy(arrayBuffer);
-
-    // Extract metadata
-    console.log("\n   --- Metadata ---");
-    try {
-      const meta = await getMeta(docProxy);
-      if (meta.info) {
-        const title = meta.info.Title || "(no title)";
-        const author = meta.info.Author || "(no author)";
-        const subject = meta.info.Subject || "(no subject)";
-        const creator = meta.info.Creator || "(no creator)";
-        console.log(`   Title:   ${title}`);
-        console.log(`   Author:  ${author}`);
-        console.log(`   Subject: ${subject}`);
-        console.log(`   Creator: ${creator}`);
-      }
-      if (meta.metadata) {
-        const metadataStr = String(meta.metadata);
-        console.log(
-          `   Raw metadata (first 200 chars): ${metadataStr.slice(0, 200)}`,
-        );
-      }
-    } catch (metaError) {
-      console.log(
-        `   Metadata extraction failed: ${normalizeError(metaError).message}`,
-      );
-    }
 
     // Extract text (per-page)
     console.log("\n   --- Text Extraction (per-page) ---");
@@ -154,7 +114,6 @@ async function validatePdf(pdfConfig) {
 }
 
 console.log("🔍 unpdf Validation Script");
-console.log(`   unpdf version: ${getUnpdfVersion()}`);
 
 const results = [];
 for (const pdf of PDFS) {

--- a/src/backend/content_extractor.ts
+++ b/src/backend/content_extractor.ts
@@ -9,7 +9,13 @@ import {
 
 // ServiceWorker環境では動的import()が禁止されているため、
 // 静的インポートでPDF.jsモジュールを事前登録する
-await definePDFJSModule(async () => unpdfPdfjs);
+let pdfjsModuleInitialized = false;
+async function ensurePdfjsModule(): Promise<void> {
+  if (!pdfjsModuleInitialized) {
+    await definePDFJSModule(async () => unpdfPdfjs);
+    pdfjsModuleInitialized = true;
+  }
+}
 
 export type ExtractContentOutcome =
   | "local-success"
@@ -155,6 +161,7 @@ async function extractPdfText(
   arrayBuffer: ArrayBuffer,
   url: string,
 ): Promise<LocalExtractResult> {
+  await ensurePdfjsModule();
   let textPages: string[];
   try {
     const docProxy = await getDocumentProxy(arrayBuffer);

--- a/src/backend/content_extractor.ts
+++ b/src/backend/content_extractor.ts
@@ -1,10 +1,15 @@
 import { readable } from "@mizchi/readability";
-import { extractText, getDocumentProxy } from "unpdf";
+import { definePDFJSModule, extractText, getDocumentProxy } from "unpdf";
+import * as unpdfPdfjs from "unpdf/pdfjs";
 import {
   type ContentExtractorProvider,
   DEFAULT_CONTENT_EXTRACTOR_PROVIDER,
   DEFAULT_TAVILY_BASE_URL,
 } from "../common/constants";
+
+// ServiceWorker環境では動的import()が禁止されているため、
+// 静的インポートでPDF.jsモジュールを事前登録する
+await definePDFJSModule(async () => unpdfPdfjs);
 
 export type ExtractContentOutcome =
   | "local-success"

--- a/src/backend/content_extractor.ts
+++ b/src/backend/content_extractor.ts
@@ -1,4 +1,5 @@
 import { readable } from "@mizchi/readability";
+import { extractText, getDocumentProxy } from "unpdf";
 import {
   type ContentExtractorProvider,
   DEFAULT_CONTENT_EXTRACTOR_PROVIDER,
@@ -134,6 +135,63 @@ function resolveFallbackTitle(url: string, title?: string): string {
   }
 }
 
+function isPdfContent(contentType: string | null, url: string): boolean {
+  if (contentType !== null) {
+    return contentType.includes("application/pdf");
+  }
+  try {
+    return new URL(url).pathname.toLowerCase().endsWith(".pdf");
+  } catch {
+    return false;
+  }
+}
+
+async function extractPdfText(
+  arrayBuffer: ArrayBuffer,
+  url: string,
+): Promise<LocalExtractResult> {
+  let textPages: string[];
+  try {
+    const docProxy = await getDocumentProxy(arrayBuffer);
+    const result = await extractText(docProxy);
+    textPages = result.text;
+  } catch (error) {
+    return {
+      success: false,
+      attempt: {
+        source: "local",
+        success: false,
+        kind: "parse-failed",
+        error: `PDFテキスト抽出に失敗しました: ${normalizeErrorMessage(error)}`,
+      },
+    };
+  }
+
+  const content = textPages.join("\n\n").trim();
+  if (!content) {
+    return {
+      success: false,
+      attempt: {
+        source: "local",
+        success: false,
+        kind: "parse-failed",
+        error: "PDFからテキストを抽出できませんでした。",
+      },
+    };
+  }
+
+  return {
+    success: true,
+    content,
+    title: resolveFallbackTitle(url),
+    attempt: {
+      source: "local",
+      success: true,
+      kind: "local-success",
+    },
+  };
+}
+
 function isBlockedStatus(status: number): boolean {
   return status === 401 || status === 403 || status === 451;
 }
@@ -161,7 +219,7 @@ export function summarizeExtractionResult(
 }
 
 /**
- * URLから本文を抽出する。ローカルHTML取得 + readability を優先し、
+ * URLから本文を抽出する。ローカル本文取得 + readability を優先し、
  * 失敗時のみ Tavily Extract API にフォールバックする。
  */
 export async function extractContent(
@@ -340,7 +398,7 @@ async function extractWithTavilyOnly(
 }
 
 async function extractLocally(url: string): Promise<LocalExtractResult> {
-  console.log(`ローカルHTML取得開始: ${url}`);
+  console.log(`ローカル本文取得開始: ${url}`);
 
   let response: Response;
   try {
@@ -359,7 +417,7 @@ async function extractLocally(url: string): Promise<LocalExtractResult> {
         source: "local",
         success: false,
         kind,
-        error: `ローカルHTML取得に失敗しました: ${normalizeErrorMessage(error)}`,
+        error: `ローカル本文取得に失敗しました: ${normalizeErrorMessage(error)}`,
       },
     };
   }
@@ -375,10 +433,18 @@ async function extractLocally(url: string): Promise<LocalExtractResult> {
         source: "local",
         success: false,
         kind,
-        error: `ローカルHTML取得に失敗しました: ${response.status} ${response.statusText}`,
+        error: `ローカル本文取得に失敗しました: ${response.status} ${response.statusText}`,
         status: response.status,
       },
     };
+  }
+
+  // PDFの場合はunpdfでテキスト抽出
+  const contentType = response.headers.get("content-type");
+  if (isPdfContent(contentType, url)) {
+    console.log(`PDFとして処理: ${url}`);
+    const arrayBuffer = await response.arrayBuffer();
+    return extractPdfText(arrayBuffer, url);
   }
 
   const html = await response.text();

--- a/src/backend/content_extractor.ts
+++ b/src/backend/content_extractor.ts
@@ -147,9 +147,11 @@ function resolveFallbackTitle(url: string, title?: string): string {
 }
 
 function isPdfContent(contentType: string | null, url: string): boolean {
-  if (contentType !== null) {
-    return contentType.includes("application/pdf");
+  const normalizedContentType = contentType?.trim().toLowerCase() ?? "";
+  if (normalizedContentType.includes("application/pdf")) {
+    return true;
   }
+
   try {
     return new URL(url).pathname.toLowerCase().endsWith(".pdf");
   } catch {
@@ -161,9 +163,9 @@ async function extractPdfText(
   arrayBuffer: ArrayBuffer,
   url: string,
 ): Promise<LocalExtractResult> {
-  await ensurePdfjsModule();
   let textPages: string[];
   try {
+    await ensurePdfjsModule();
     const docProxy = await getDocumentProxy(arrayBuffer);
     const result = await extractText(docProxy);
     textPages = result.text;
@@ -218,7 +220,7 @@ function isFetchBlockedError(error: unknown): boolean {
 
 function formatAttempt(attempt: ExtractAttempt): string {
   const status = attempt.status !== undefined ? `(${attempt.status})` : "";
-  const error = attempt.success || !attempt.error ? "" : `:${attempt.error}`;
+  const error = !attempt.success && attempt.error ? `:${attempt.error}` : "";
   return `${attempt.source}:${attempt.kind}${status}${error}`;
 }
 
@@ -455,7 +457,21 @@ async function extractLocally(url: string): Promise<LocalExtractResult> {
   const contentType = response.headers.get("content-type");
   if (isPdfContent(contentType, url)) {
     console.log(`PDFとして処理: ${url}`);
-    const arrayBuffer = await response.arrayBuffer();
+    let arrayBuffer: ArrayBuffer;
+    try {
+      arrayBuffer = await response.arrayBuffer();
+    } catch (error) {
+      return {
+        success: false,
+        attempt: {
+          source: "local",
+          success: false,
+          kind: "fetch-failed",
+          error: `PDF本文取得に失敗しました: ${normalizeErrorMessage(error)}`,
+        },
+      };
+    }
+
     return extractPdfText(arrayBuffer, url);
   }
 

--- a/tests/backend/background.test.ts
+++ b/tests/backend/background.test.ts
@@ -34,7 +34,7 @@ function createExtractSuccessResult(
 }
 
 function createExtractFailureResult(
-  error = "ローカルHTML取得に失敗しました: 403 Forbidden",
+  error = "ローカル本文取得に失敗しました: 403 Forbidden",
 ): ExtractContentResult {
   return {
     success: false,

--- a/tests/backend/content_extractor.test.ts
+++ b/tests/backend/content_extractor.test.ts
@@ -4,9 +4,16 @@ import { DEFAULT_TAVILY_BASE_URL } from "../../src/common/constants";
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
+// unpdfをモック
+vi.mock("unpdf", () => ({
+  getDocumentProxy: vi.fn(),
+  extractText: vi.fn(),
+}));
+
 const { extractContent, summarizeExtractionResult } = await import(
   "../../src/backend/content_extractor"
 );
+const { getDocumentProxy, extractText } = await import("unpdf");
 
 const localArticleHtml = `<!doctype html>
 <html>
@@ -35,6 +42,25 @@ const nonArticleHtml = `<!doctype html>
   </body>
 </html>`;
 
+/** モック用のResponse風オブジェクトを作成するヘルパー */
+function createMockResponse(overrides: Record<string, unknown> = {}) {
+  const { headers: headersOverride, ...rest } = overrides;
+  const headers =
+    typeof headersOverride === "object" && headersOverride !== null
+      ? headersOverride
+      : { get: () => null };
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    headers,
+    text: async () => "",
+    arrayBuffer: async () => new ArrayBuffer(0),
+    json: async () => ({}),
+    ...rest,
+  };
+}
+
 describe("extractContent", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -47,10 +73,9 @@ describe("extractContent", () => {
   });
 
   it("ローカルHTML取得と readability で本文抽出に成功する", async () => {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      text: async () => localArticleHtml,
-    });
+    mockFetch.mockResolvedValue(
+      createMockResponse({ text: async () => localArticleHtml }),
+    );
 
     const result = await extractContent("https://example.com/article", {});
 
@@ -81,23 +106,26 @@ describe("extractContent", () => {
     const mockContent = "# Tavilyタイトル\n\nTavily本文";
     const mockTitle = "Tavilyタイトル";
     mockFetch
-      .mockResolvedValueOnce({
-        ok: false,
-        status: 403,
-        statusText: "Forbidden",
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          results: [
-            {
-              url: "https://example.com/article",
-              raw_content: mockContent,
-              title: mockTitle,
-            },
-          ],
+      .mockResolvedValueOnce(
+        createMockResponse({
+          ok: false,
+          status: 403,
+          statusText: "Forbidden",
         }),
-      });
+      )
+      .mockResolvedValueOnce(
+        createMockResponse({
+          json: async () => ({
+            results: [
+              {
+                url: "https://example.com/article",
+                raw_content: mockContent,
+                title: mockTitle,
+              },
+            ],
+          }),
+        }),
+      );
 
     const result = await extractContent("https://example.com/article", {
       tavily: { apiKey: "tv-test-key" },
@@ -114,7 +142,7 @@ describe("extractContent", () => {
           source: "local",
           success: false,
           kind: "fetch-blocked",
-          error: "ローカルHTML取得に失敗しました: 403 Forbidden",
+          error: "ローカル本文取得に失敗しました: 403 Forbidden",
           status: 403,
         },
         {
@@ -145,18 +173,19 @@ describe("extractContent", () => {
   it("Tavily モードではローカル取得を行わずに本文抽出する", async () => {
     const mockContent = "# Tavilyタイトル\n\nTavily本文";
     const mockTitle = "Tavilyタイトル";
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        results: [
-          {
-            url: "https://example.com/article",
-            raw_content: mockContent,
-            title: mockTitle,
-          },
-        ],
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse({
+        json: async () => ({
+          results: [
+            {
+              url: "https://example.com/article",
+              raw_content: mockContent,
+              title: mockTitle,
+            },
+          ],
+        }),
       }),
-    });
+    );
 
     const result = await extractContent("https://example.com/article", {
       mode: "tavily",
@@ -224,14 +253,14 @@ describe("extractContent", () => {
 
     expect(result.outcome).toBe("local-failed-no-fallback");
     expect(result.error).toBe(
-      "ローカルHTML取得に失敗しました: Failed to fetch",
+      "ローカル本文取得に失敗しました: Failed to fetch",
     );
     expect(result.attempts).toEqual([
       {
         source: "local",
         success: false,
         kind: "fetch-blocked",
-        error: "ローカルHTML取得に失敗しました: Failed to fetch",
+        error: "ローカル本文取得に失敗しました: Failed to fetch",
       },
       {
         source: "tavily",
@@ -243,22 +272,23 @@ describe("extractContent", () => {
   });
 
   it("ローカル parse 失敗後に Tavily も失敗したら両方の失敗を返す", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      text: async () => nonArticleHtml,
-    });
-    mockFetch.mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        results: [],
-        failed_results: [
-          {
-            url: "https://example.com/article",
-            error: "Rate limited",
-          },
-        ],
-      }),
-    });
+    mockFetch
+      .mockResolvedValueOnce(
+        createMockResponse({ text: async () => nonArticleHtml }),
+      )
+      .mockResolvedValue(
+        createMockResponse({
+          json: async () => ({
+            results: [],
+            failed_results: [
+              {
+                url: "https://example.com/article",
+                error: "Rate limited",
+              },
+            ],
+          }),
+        }),
+      );
 
     const extractPromise = extractContent("https://example.com/article", {
       mode: "local-with-tavily-fallback",
@@ -299,24 +329,27 @@ describe("extractContent", () => {
   it("Tavily フォールバックはリトライ後に回復できる", async () => {
     const mockContent = "# 回復成功\n\n最終的に成功した内容";
     mockFetch
-      .mockResolvedValueOnce({
-        ok: false,
-        status: 403,
-        statusText: "Forbidden",
-      })
-      .mockRejectedValueOnce(new Error("API timeout"))
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          results: [
-            {
-              url: "https://example.com/article",
-              raw_content: mockContent,
-              title: "回復成功",
-            },
-          ],
+      .mockResolvedValueOnce(
+        createMockResponse({
+          ok: false,
+          status: 403,
+          statusText: "Forbidden",
         }),
-      });
+      )
+      .mockRejectedValueOnce(new Error("API timeout"))
+      .mockResolvedValueOnce(
+        createMockResponse({
+          json: async () => ({
+            results: [
+              {
+                url: "https://example.com/article",
+                raw_content: mockContent,
+                title: "回復成功",
+              },
+            ],
+          }),
+        }),
+      );
 
     const extractPromise = extractContent("https://example.com/article", {
       mode: "local-with-tavily-fallback",
@@ -336,7 +369,7 @@ describe("extractContent", () => {
           source: "local",
           success: false,
           kind: "fetch-blocked",
-          error: "ローカルHTML取得に失敗しました: 403 Forbidden",
+          error: "ローカル本文取得に失敗しました: 403 Forbidden",
           status: 403,
         },
         {
@@ -350,23 +383,26 @@ describe("extractContent", () => {
 
   it("抽出サマリーでローカル失敗と Tavily 成功を区別できる", async () => {
     mockFetch
-      .mockResolvedValueOnce({
-        ok: false,
-        status: 403,
-        statusText: "Forbidden",
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          results: [
-            {
-              url: "https://example.com/article",
-              raw_content: "# Tavily\n\n本文",
-              title: "Tavily",
-            },
-          ],
+      .mockResolvedValueOnce(
+        createMockResponse({
+          ok: false,
+          status: 403,
+          statusText: "Forbidden",
         }),
-      });
+      )
+      .mockResolvedValueOnce(
+        createMockResponse({
+          json: async () => ({
+            results: [
+              {
+                url: "https://example.com/article",
+                raw_content: "# Tavily\n\n本文",
+                title: "Tavily",
+              },
+            ],
+          }),
+        }),
+      );
 
     const result = await extractContent("https://example.com/article", {
       mode: "local-with-tavily-fallback",
@@ -374,7 +410,188 @@ describe("extractContent", () => {
     });
 
     expect(summarizeExtractionResult(result)).toBe(
-      "outcome=tavily-fallback-success; attempts=local:fetch-blocked(403):ローカルHTML取得に失敗しました: 403 Forbidden -> tavily:tavily-success",
+      "outcome=tavily-fallback-success; attempts=local:fetch-blocked(403):ローカル本文取得に失敗しました: 403 Forbidden -> tavily:tavily-success",
     );
+  });
+
+  describe("PDF抽出", () => {
+    it("Content-Type が application/pdf の場合、unpdfでテキスト抽出に成功する", async () => {
+      const mockDocProxy = {};
+      const mockPdfText = ["1ページ目のテキスト", "2ページ目のテキスト"];
+      vi.mocked(getDocumentProxy).mockResolvedValueOnce(mockDocProxy as never);
+      vi.mocked(extractText).mockResolvedValueOnce({
+        totalPages: 2,
+        text: mockPdfText,
+      } as never);
+
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          headers: {
+            get: (name: string) =>
+              name === "content-type" ? "application/pdf" : null,
+          },
+          arrayBuffer: async () => new ArrayBuffer(100),
+        }),
+      );
+
+      const result = await extractContent("https://example.com/paper.pdf", {});
+
+      expect(result).toEqual({
+        success: true,
+        content: "1ページ目のテキスト\n\n2ページ目のテキスト",
+        title: "example.com",
+        source: "local",
+        outcome: "local-success",
+        attempts: [
+          {
+            source: "local",
+            success: true,
+            kind: "local-success",
+          },
+        ],
+      });
+      expect(getDocumentProxy).toHaveBeenCalledTimes(1);
+      expect(extractText).toHaveBeenCalledWith(mockDocProxy);
+    });
+
+    it("Content-Type ヘッダーがなくてもURLが.pdfで終わる場合はPDFとして処理する", async () => {
+      const mockDocProxy = {};
+      const mockPdfText = ["PDF本文テキスト"];
+      vi.mocked(getDocumentProxy).mockResolvedValueOnce(mockDocProxy as never);
+      vi.mocked(extractText).mockResolvedValueOnce({
+        totalPages: 1,
+        text: mockPdfText,
+      } as never);
+
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          headers: { get: () => null },
+          arrayBuffer: async () => new ArrayBuffer(100),
+        }),
+      );
+
+      const result = await extractContent(
+        "https://example.com/docs/whitepaper.pdf",
+        {},
+      );
+
+      expect(result.success).toBe(true);
+      if (!result.success) throw new Error("Expected success");
+      expect(result.content).toBe("PDF本文テキスト");
+      expect(result.source).toBe("local");
+      expect(result.outcome).toBe("local-success");
+    });
+
+    it("PDFテキスト抽出結果が空の場合は parse-failed となる", async () => {
+      const mockDocProxy = {};
+      vi.mocked(getDocumentProxy).mockResolvedValueOnce(mockDocProxy as never);
+      vi.mocked(extractText).mockResolvedValueOnce({
+        totalPages: 1,
+        text: [""],
+      } as never);
+
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          headers: { get: () => "application/pdf" },
+          arrayBuffer: async () => new ArrayBuffer(100),
+        }),
+      );
+
+      const result = await extractContent("https://example.com/empty.pdf", {});
+
+      expect(result.success).toBe(false);
+      if (result.success) throw new Error("Expected failure");
+      expect(result.outcome).toBe("local-failed-no-fallback");
+      expect(result.attempts[0]).toEqual({
+        source: "local",
+        success: false,
+        kind: "parse-failed",
+        error: "PDFからテキストを抽出できませんでした。",
+      });
+    });
+
+    it("PDF抽出失敗時にTavilyフォールバックが機能する", async () => {
+      const mockDocProxy = {};
+      vi.mocked(getDocumentProxy).mockResolvedValueOnce(mockDocProxy as never);
+      vi.mocked(extractText).mockRejectedValueOnce(
+        new Error("PDF parsing error") as never,
+      );
+
+      const mockTavilyContent = "# Tavily PDF本文\n\nPDFの代替コンテンツ";
+      mockFetch
+        .mockResolvedValueOnce(
+          createMockResponse({
+            headers: { get: () => "application/pdf" },
+            arrayBuffer: async () => new ArrayBuffer(100),
+          }),
+        )
+        .mockResolvedValueOnce(
+          createMockResponse({
+            json: async () => ({
+              results: [
+                {
+                  url: "https://example.com/paper.pdf",
+                  raw_content: mockTavilyContent,
+                  title: "Tavily PDFタイトル",
+                },
+              ],
+            }),
+          }),
+        );
+
+      const result = await extractContent("https://example.com/paper.pdf", {
+        tavily: { apiKey: "tv-test-key" },
+      });
+
+      expect(result).toEqual({
+        success: true,
+        content: mockTavilyContent,
+        title: "Tavily PDFタイトル",
+        source: "tavily",
+        outcome: "tavily-fallback-success",
+        attempts: [
+          {
+            source: "local",
+            success: false,
+            kind: "parse-failed",
+            error: "PDFテキスト抽出に失敗しました: PDF parsing error",
+          },
+          {
+            source: "tavily",
+            success: true,
+            kind: "tavily-success",
+          },
+        ],
+      });
+    });
+
+    it("PDFではないContent-Typeの場合はreadabilityで処理する", async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          headers: { get: () => "text/html; charset=utf-8" },
+          text: async () => localArticleHtml,
+        }),
+      );
+
+      const result = await extractContent("https://example.com/article", {});
+
+      expect(result).toEqual({
+        success: true,
+        content: expect.stringContaining("# Local Title"),
+        title: "Local Title",
+        source: "local",
+        outcome: "local-success",
+        attempts: [
+          {
+            source: "local",
+            success: true,
+            kind: "local-success",
+          },
+        ],
+      });
+      // readabilityが使われ、unpdfは呼ばれないことを確認
+      expect(getDocumentProxy).not.toHaveBeenCalled();
+      expect(extractText).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/backend/content_extractor.test.ts
+++ b/tests/backend/content_extractor.test.ts
@@ -6,8 +6,14 @@ vi.stubGlobal("fetch", mockFetch);
 
 // unpdfをモック
 vi.mock("unpdf", () => ({
+  definePDFJSModule: vi.fn(),
   getDocumentProxy: vi.fn(),
   extractText: vi.fn(),
+}));
+
+// unpdf/pdfjsをモック（静的インポート用）
+vi.mock("unpdf/pdfjs", () => ({
+  default: {},
 }));
 
 const { extractContent, summarizeExtractionResult } = await import(

--- a/tests/backend/content_extractor.test.ts
+++ b/tests/backend/content_extractor.test.ts
@@ -421,7 +421,7 @@ describe("extractContent", () => {
   });
 
   describe("PDF抽出", () => {
-    it("Content-Type が application/pdf の場合、unpdfでテキスト抽出に成功する", async () => {
+    it("Content-Type が大文字小文字違いでもPDFとして扱い、unpdfでテキスト抽出に成功する", async () => {
       const mockDocProxy = {};
       const mockPdfText = ["1ページ目のテキスト", "2ページ目のテキスト"];
       vi.mocked(getDocumentProxy).mockResolvedValueOnce(mockDocProxy as never);
@@ -434,7 +434,9 @@ describe("extractContent", () => {
         createMockResponse({
           headers: {
             get: (name: string) =>
-              name === "content-type" ? "application/pdf" : null,
+              name === "content-type"
+                ? "Application/PDF; charset=binary"
+                : null,
           },
           arrayBuffer: async () => new ArrayBuffer(100),
         }),
@@ -460,7 +462,7 @@ describe("extractContent", () => {
       expect(extractText).toHaveBeenCalledWith(mockDocProxy);
     });
 
-    it("Content-Type ヘッダーがなくてもURLが.pdfで終わる場合はPDFとして処理する", async () => {
+    it("Content-Type が PDF 以外でもURLが.pdfで終わる場合はPDFとして処理する", async () => {
       const mockDocProxy = {};
       const mockPdfText = ["PDF本文テキスト"];
       vi.mocked(getDocumentProxy).mockResolvedValueOnce(mockDocProxy as never);
@@ -471,7 +473,7 @@ describe("extractContent", () => {
 
       mockFetch.mockResolvedValueOnce(
         createMockResponse({
-          headers: { get: () => null },
+          headers: { get: () => "application/octet-stream" },
           arrayBuffer: async () => new ArrayBuffer(100),
         }),
       );
@@ -486,6 +488,57 @@ describe("extractContent", () => {
       expect(result.content).toBe("PDF本文テキスト");
       expect(result.source).toBe("local");
       expect(result.outcome).toBe("local-success");
+    });
+
+    it("PDFレスポンスの arrayBuffer 読み取り失敗時も Tavily にフォールバックする", async () => {
+      const mockTavilyContent = "# Tavily PDF本文\n\nPDFの代替コンテンツ";
+      mockFetch
+        .mockResolvedValueOnce(
+          createMockResponse({
+            headers: { get: () => "application/pdf" },
+            arrayBuffer: async () => {
+              throw new Error("Body stream aborted");
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          createMockResponse({
+            json: async () => ({
+              results: [
+                {
+                  url: "https://example.com/paper.pdf",
+                  raw_content: mockTavilyContent,
+                  title: "Tavily PDFタイトル",
+                },
+              ],
+            }),
+          }),
+        );
+
+      const result = await extractContent("https://example.com/paper.pdf", {
+        tavily: { apiKey: "tv-test-key" },
+      });
+
+      expect(result).toEqual({
+        success: true,
+        content: mockTavilyContent,
+        title: "Tavily PDFタイトル",
+        source: "tavily",
+        outcome: "tavily-fallback-success",
+        attempts: [
+          {
+            source: "local",
+            success: false,
+            kind: "fetch-failed",
+            error: "PDF本文取得に失敗しました: Body stream aborted",
+          },
+          {
+            source: "tavily",
+            success: true,
+            kind: "tavily-success",
+          },
+        ],
+      });
     });
 
     it("PDFテキスト抽出結果が空の場合は parse-failed となる", async () => {

--- a/tests/backend/message_handling.test.ts
+++ b/tests/backend/message_handling.test.ts
@@ -206,7 +206,7 @@ describe("Message handling", () => {
           source: "local",
           success: false,
           kind: "fetch-blocked",
-          error: "ローカルHTML取得に失敗しました: Failed to fetch",
+          error: "ローカル本文取得に失敗しました: Failed to fetch",
         },
         {
           source: "tavily",

--- a/tests/frontend/options.test.ts
+++ b/tests/frontend/options.test.ts
@@ -308,14 +308,14 @@ describe("ContentExtractorTest", () => {
   it("Tavilyキー未設定のローカル失敗では要約を実行しない", async () => {
     mockChromeRuntime.sendMessage.mockResolvedValueOnce({
       success: false,
-      error: "ローカルHTML取得に失敗しました: 403 Forbidden",
+      error: "ローカル本文取得に失敗しました: 403 Forbidden",
       outcome: "local-failed-no-fallback",
       attempts: [
         {
           source: "local",
           success: false,
           kind: "fetch-blocked",
-          error: "ローカルHTML取得に失敗しました: 403 Forbidden",
+          error: "ローカル本文取得に失敗しました: 403 Forbidden",
           status: 403,
         },
         {


### PR DESCRIPTION
Copilot CLI + OpenRouter GLM-5.1 で実装

## 概要

Issue #74 の実装です。PDFのURLを要約しようとした際、readabilityでHTML解析できずTavilyにフォールバックしていた問題を解決します。

## 変更内容

- **unpdfライブラリの導入**: PDFからのテキスト抽出をローカルで行えるようにしました
- **PDF判定ロジック追加**: Content-Type: application/pdf ヘッダーまたはURL拡張子 .pdf でPDFを判定
- **extractLocally()の拡張**: PDFの場合はunpdfの getDocumentProxy() + extractText() でテキスト抽出
- **フォールバック維持**: PDF抽出失敗時は既存のTavilyフォールバックが機能
- **検証スクリプト追加**: scripts/validate-unpdf.mjs で2つのサンプルPDFでテキスト抽出を検証済み

## テスト追加

- Content-Typeが application/pdf の場合のPDF抽出成功テスト
- URL拡張子 .pdf でのPDF判定テスト
- PDFテキスト抽出結果が空の場合の parse-failed テスト
- PDF抽出失敗時のTavilyフォールバックテスト
- PDFではないContent-Typeの場合のreadability継続テスト

## 検証結果

2つのサンプルPDFでテキスト抽出を検証:
- Google Prompt Engineering Whitepaper: 56ページ、50,063文字を正常抽出
- DeNA AI 100 Tips Slide: 101ページ、49,787文字を正常抽出

## 注意事項

- pdfjs-distがバンドルに含まれるため、background.jsのサイズが増大しています（約2.1MB / gzip 565KB）
- エラーメッセージをローカルHTML取得からローカル本文取得に統一しました
