### PR TITLE
アラーム設定更新メッセージハンドラーの実装

### DIFF
--- a/src/backend/background.ts
+++ b/src/backend/background.ts
@@ -17,7 +17,9 @@ import type {
   FrontendMessage,
   ManualExecuteResult,
   SlackTestResult,
+  UpdateAlarmResult,
 } from "../types/messages";
+import { setupAlarm } from "./alarm";
 import {
   type ExtractContentConfig,
   type ExtractContentResult,
@@ -34,7 +36,6 @@ import {
   type SummarizerConfig,
   summarizeContent,
 } from "./summarizer";
-import "./alarm"; // アラーム処理の初期化
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -69,7 +70,8 @@ type MessageResponse =
   | ExtractContentResult
   | SummarizeResult
   | SlackTestResult
-  | ManualExecuteResult;
+  | ManualExecuteResult
+  | UpdateAlarmResult;
 
 function sendAsyncMessageResponse(
   responsePromise: Promise<MessageResponse>,
@@ -178,6 +180,13 @@ function initializeMessageHandlers(): void {
           );
         }
 
+        if (request.type === "UPDATE_ALARM") {
+          return sendAsyncMessageResponse(
+            handleUpdateAlarmMessage(),
+            sendResponse,
+          );
+        }
+
         return false;
       },
     );
@@ -275,6 +284,15 @@ async function handleSlackTestMessage(
 async function handleManualExecuteMessage(): Promise<ManualExecuteResult> {
   await processReadingListEntries("manual");
   return { success: true };
+}
+
+async function handleUpdateAlarmMessage(): Promise<UpdateAlarmResult> {
+  try {
+    await setupAlarm();
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: getErrorMessage(error) };
+  }
 }
 
 // Initialize message handlers

--- a/src/frontend/options/options.tsx
+++ b/src/frontend/options/options.tsx
@@ -386,9 +386,7 @@ export function App(): JSX.Element {
 
     try {
       await saveSettingsToStorage(validatedSettings);
-      await chrome.runtime
-        .sendMessage({ type: "UPDATE_ALARM" })
-        .catch(() => {});
+      void chrome.runtime.sendMessage({ type: "UPDATE_ALARM" }).catch(() => {});
       setSettings(formatSettingsForUi(validatedSettings));
       setSaveStatus("success");
       setSaveMessage("設定を保存しました。");

--- a/src/frontend/options/options.tsx
+++ b/src/frontend/options/options.tsx
@@ -386,6 +386,9 @@ export function App(): JSX.Element {
 
     try {
       await saveSettingsToStorage(validatedSettings);
+      await chrome.runtime
+        .sendMessage({ type: "UPDATE_ALARM" })
+        .catch(() => {});
       setSettings(formatSettingsForUi(validatedSettings));
       setSaveStatus("success");
       setSaveMessage("設定を保存しました。");

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -62,6 +62,12 @@ export interface ManualExecuteResult {
   error?: string;
 }
 
+export interface UpdateAlarmMessage extends BaseMessage {
+  type: "UPDATE_ALARM";
+}
+
+export type UpdateAlarmResult = ManualExecuteResult;
+
 /**
  * Union type for all frontend messages
  */
@@ -69,4 +75,5 @@ export type FrontendMessage =
   | ExtractContentMessage
   | SummarizeTestMessage
   | SlackTestMessage
-  | ManualExecuteMessage;
+  | ManualExecuteMessage
+  | UpdateAlarmMessage;

--- a/tests/backend/message_handling.test.ts
+++ b/tests/backend/message_handling.test.ts
@@ -84,6 +84,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.clearAllMocks();
   vi.unstubAllGlobals();
   vi.doUnmock("../../src/backend/background");
@@ -129,8 +130,6 @@ describe("Message handling", () => {
       mode: "local-with-tavily-fallback",
     });
     expect(sendResponse).toHaveBeenCalledWith(mockResult);
-
-    vi.useRealTimers();
   });
 
   it("Tavily API キーがあれば既定モード付きで抽出を実行する", async () => {
@@ -160,8 +159,6 @@ describe("Message handling", () => {
       },
     });
     expect(sendResponse).toHaveBeenCalledWith(mockResult);
-
-    vi.useRealTimers();
   });
 
   it("Tavily モードが選択されていればそのモードで抽出を実行する", async () => {
@@ -192,8 +189,6 @@ describe("Message handling", () => {
       },
     });
     expect(sendResponse).toHaveBeenCalledWith(mockResult);
-
-    vi.useRealTimers();
   });
 
   it("extractContent が失敗結果を返した場合はそのまま返す", async () => {
@@ -233,8 +228,6 @@ describe("Message handling", () => {
     await vi.runAllTimersAsync();
 
     expect(sendResponse).toHaveBeenCalledWith(mockError);
-
-    vi.useRealTimers();
   });
 
   it("不明なメッセージタイプは無視する", () => {
@@ -270,8 +263,6 @@ describe("Message handling", () => {
     expect(result).toBe(true);
     await vi.runAllTimersAsync();
     expect(sendResponse).toHaveBeenCalledWith({ success: true });
-
-    vi.useRealTimers();
   });
 
   it("UPDATE_ALARM メッセージで setupAlarm を呼び成功レスポンスを返す", async () => {
@@ -291,8 +282,6 @@ describe("Message handling", () => {
     await vi.runAllTimersAsync();
     expect(mockSetupAlarm).toHaveBeenCalledTimes(1);
     expect(sendResponse).toHaveBeenCalledWith({ success: true });
-
-    vi.useRealTimers();
   });
 
   it("UPDATE_ALARM メッセージで setupAlarm が失敗したとき失敗レスポンスを返す", async () => {
@@ -314,7 +303,5 @@ describe("Message handling", () => {
       success: false,
       error: "alarm error",
     });
-
-    vi.useRealTimers();
   });
 });

--- a/tests/backend/message_handling.test.ts
+++ b/tests/backend/message_handling.test.ts
@@ -16,7 +16,10 @@ vi.mock("../../src/backend/content_extractor", () => ({
   ),
 }));
 
-vi.mock("../../src/backend/alarm", () => ({}));
+const mockSetupAlarm = vi.fn();
+vi.mock("../../src/backend/alarm", () => ({
+  setupAlarm: mockSetupAlarm,
+}));
 
 // Chrome API のモック設定
 const mockChromeStorageLocal = {
@@ -267,6 +270,50 @@ describe("Message handling", () => {
     expect(result).toBe(true);
     await vi.runAllTimersAsync();
     expect(sendResponse).toHaveBeenCalledWith({ success: true });
+
+    vi.useRealTimers();
+  });
+
+  it("UPDATE_ALARM メッセージで setupAlarm を呼び成功レスポンスを返す", async () => {
+    vi.useFakeTimers();
+    mockSetupAlarm.mockResolvedValue(undefined);
+    const sendResponse = vi.fn();
+    const request = { type: "UPDATE_ALARM" };
+
+    const listener = getMessageListener();
+    const result = listener(
+      request,
+      {} as chrome.runtime.MessageSender,
+      sendResponse,
+    );
+
+    expect(result).toBe(true);
+    await vi.runAllTimersAsync();
+    expect(mockSetupAlarm).toHaveBeenCalledTimes(1);
+    expect(sendResponse).toHaveBeenCalledWith({ success: true });
+
+    vi.useRealTimers();
+  });
+
+  it("UPDATE_ALARM メッセージで setupAlarm が失敗したとき失敗レスポンスを返す", async () => {
+    vi.useFakeTimers();
+    mockSetupAlarm.mockRejectedValue(new Error("alarm error"));
+    const sendResponse = vi.fn();
+    const request = { type: "UPDATE_ALARM" };
+
+    const listener = getMessageListener();
+    const result = listener(
+      request,
+      {} as chrome.runtime.MessageSender,
+      sendResponse,
+    );
+
+    expect(result).toBe(true);
+    await vi.runAllTimersAsync();
+    expect(sendResponse).toHaveBeenCalledWith({
+      success: false,
+      error: "alarm error",
+    });
 
     vi.useRealTimers();
   });


### PR DESCRIPTION
fix: #88

## 概要
設定保存時にアラーム設定を更新するためのメッセージハンドラーを実装しました。フロントエンドから`UPDATE_ALARM`メッセージを送信して、バックグラウンドスクリプトのアラーム設定を動的に更新できるようになります。

## 主な変更点

- **メッセージハンドラーの追加**: `src/backend/background.ts`に`handleUpdateAlarmMessage()`関数を実装し、`UPDATE_ALARM`メッセージを処理するロジックを追加
- **型定義の拡張**: `src/types/messages.ts`に`UpdateAlarmMessage`インターフェースと`UpdateAlarmResult`型を追加し、新しいメッセージタイプをサポート
- **フロントエンド統合**: `src/frontend/options/options.tsx`の設定保存処理後に`UPDATE_ALARM`メッセージを送信
- **アラーム初期化の改善**: `src/backend/background.ts`から`import "./alarm"`を削除し、`setupAlarm`を明示的にインポート・呼び出すように変更
- **テストカバレッジ**: `tests/backend/message_handling.test.ts`に成功・失敗ケースの2つのテストを追加

## 実装の詳細

- `setupAlarm()`関数を直接呼び出すことで、設定変更時にアラーム設定を動的に更新可能に
- エラーハンドリングにより、アラーム設定失敗時も適切なエラーレスポンスを返却
- フロントエンドの設定保存後に非同期でメッセージを送信し、エラーは無視（`.catch(() => {})`）

https://claude.ai/code/session_01B2EziS1m9bof719D77WUe7