### PR TITLE
dependenciesを最新化

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   },
   "dependencies": {
     "@mizchi/readability": "^0.7.7",
-    "openai": "^5.16.0",
-    "preact": "^10.27.3",
-    "unpdf": "^1.6.0"
+    "openai": "^6.42.0",
+    "preact": "^10.29.2",
+    "unpdf": "^1.6.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,21 +12,21 @@ importers:
         specifier: ^0.7.7
         version: 0.7.7
       openai:
-        specifier: ^5.16.0
-        version: 5.16.0(zod@3.25.76)
+        specifier: ^6.42.0
+        version: 6.42.0(zod@3.25.76)
       preact:
-        specifier: ^10.27.3
-        version: 10.27.3
+        specifier: ^10.29.2
+        version: 10.29.2
       unpdf:
-        specifier: ^1.6.0
-        version: 1.6.0
+        specifier: ^1.6.2
+        version: 1.6.2
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.16
         version: 2.4.16
       '@preact/preset-vite':
         specifier: ^2.10.5
-        version: 2.10.5(@babel/core@7.28.3)(preact@10.27.3)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
+        version: 2.10.5(@babel/core@7.28.3)(preact@10.29.2)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
       '@tailwindcss/vite':
         specifier: ^4.3.0
         version: 4.3.0(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
@@ -1168,12 +1168,11 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
-  openai@5.16.0:
-    resolution: {integrity: sha512-hoEH8ZNvg1HXjU9mp88L/ZH8O082Z8r6FHCXGiWAzVRrEv443aI57qhch4snu07yQydj+AUAWLenAiBXhu89Tw==}
-    hasBin: true
+  openai@6.42.0:
+    resolution: {integrity: sha512-1WFEt/uXMXOLhYRNkgJWo08Y2YNvNwpVU72K7ibrWgWpNOXd4VojXLbe6SQ4bLiUQ3Y8jz4IiyVkylJCL1DtZg==}
     peerDependencies:
       ws: ^8.18.0
-      zod: ^3.23.8
+      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       ws:
         optional: true
@@ -1216,8 +1215,8 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
-  preact@10.27.3:
-    resolution: {integrity: sha512-ZieIP3zQHiQsNF3BA+SNVS8dcuRIg/nsxlkFbCMBLS2L1Ww4Bkxd9n6Md2A1crfTZsEbQPADV0neYmh/EElgeQ==}
+  preact@10.29.2:
+    resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -1398,8 +1397,8 @@ packages:
     resolution: {integrity: sha512-+t2Z/GwkZQDtu00813aP66ygViGtPHKhhoFZpQKpKrE+9jIgES+Zw+mFNaDWOVRKiuJjuqKHzD3B1sfGg8+ZOQ==}
     engines: {node: '>=20.18.1'}
 
-  unpdf@1.6.0:
-    resolution: {integrity: sha512-DsjbuDe6PDbZzGvAP40QQp0xskrXP3Tm3fd/FLkGObL00Icr7cc28QgrPHYg+6B1lMWydgXwDXauIv5CGyXudA==}
+  unpdf@1.6.2:
+    resolution: {integrity: sha512-zQ80ySoPuPHOsvIoRp/nJyQt8TOUoTh1+WBCGcBvlddQNgKDLRwm0AY3x8Q35I7+kIiRSgqMx+Ma2pl9McIp7A==}
     peerDependencies:
       '@napi-rs/canvas': ^0.1.69
     peerDependenciesMeta:
@@ -1861,12 +1860,12 @@ snapshots:
 
   '@oxc-project/types@0.133.0': {}
 
-  '@preact/preset-vite@2.10.5(@babel/core@7.28.3)(preact@10.27.3)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))':
+  '@preact/preset-vite@2.10.5(@babel/core@7.28.3)(preact@10.29.2)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))':
     dependencies:
       '@babel/core': 7.28.3
       '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.28.3)
       '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.28.3)
-      '@prefresh/vite': 2.4.12(preact@10.27.3)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
+      '@prefresh/vite': 2.4.12(preact@10.29.2)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
       '@rollup/pluginutils': 5.4.0
       babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.28.3)
       debug: 4.4.3
@@ -1882,20 +1881,20 @@ snapshots:
 
   '@prefresh/babel-plugin@0.5.2': {}
 
-  '@prefresh/core@1.5.7(preact@10.27.3)':
+  '@prefresh/core@1.5.7(preact@10.29.2)':
     dependencies:
-      preact: 10.27.3
+      preact: 10.29.2
 
   '@prefresh/utils@1.2.1': {}
 
-  '@prefresh/vite@2.4.12(preact@10.27.3)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))':
+  '@prefresh/vite@2.4.12(preact@10.29.2)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))':
     dependencies:
       '@babel/core': 7.28.3
       '@prefresh/babel-plugin': 0.5.2
-      '@prefresh/core': 1.5.7(preact@10.27.3)
+      '@prefresh/core': 1.5.7(preact@10.29.2)
       '@prefresh/utils': 1.2.1
       '@rollup/pluginutils': 4.2.1
-      preact: 10.27.3
+      preact: 10.29.2
       vite: 8.0.16(@types/node@25.9.1)(jiti@2.7.0)
     transitivePeerDependencies:
       - supports-color
@@ -2625,7 +2624,7 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  openai@5.16.0(zod@3.25.76):
+  openai@6.42.0(zod@3.25.76):
     optionalDependencies:
       zod: 3.25.76
 
@@ -2655,7 +2654,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  preact@10.27.3: {}
+  preact@10.29.2: {}
 
   proxy-addr@2.0.7:
     dependencies:
@@ -2851,7 +2850,7 @@ snapshots:
 
   undici@7.27.0: {}
 
-  unpdf@1.6.0: {}
+  unpdf@1.6.2: {}
 
   unpipe@1.0.0: {}
 


### PR DESCRIPTION
## 概要
- runtime dependencies を最新化しました
- 更新対象は `openai`、`preact`、`unpdf` です
- アプリケーションコードの変更はありません

## 更新内容
- `openai`: `^5.16.0` → `^6.42.0`
- `preact`: `^10.27.3` → `^10.29.2`
- `unpdf`: `^1.6.0` → `^1.6.2`

## 確認内容
- `pnpm check:ai` を実行し、type-check / lint / test / build がすべて成功

## 補足
- `pnpm peers check` では `vite-prerender-plugin@0.5.11` が `vite 5/6/7` を要求する peer warning を表示しますが、今回の runtime dependency 更新とは別件で、現状 `pnpm check:ai` は通過しています
- `openai` はメジャー更新ですが、現行の `chat.completions.create(...)` 利用箇所に対する既存テストは通過しています
