### PR TITLE
GitHub Actions のマイナーバージョンを手動更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,17 +19,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install mise tools (node + pnpm)
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
 
       - name: Get pnpm store path
         id: pnpm-store
         run: echo "dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: Cache pnpm store
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ${{ steps.pnpm-store.outputs.dir }}
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -30,17 +30,17 @@ jobs:
     # If you do not check out your code, Copilot will do this for you.
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install mise tools (node + pnpm)
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
 
       - name: Get pnpm store path
         id: pnpm-store
         run: echo "dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: Cache pnpm store
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ${{ steps.pnpm-store.outputs.dir }}
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       tag_name: ${{ steps.release-drafter.outputs.tag_name }}
     steps:
       # Get next version
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@v6.4.0
         id: release-drafter
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -33,7 +33,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     needs: draft_release
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@v6.4.0
         id: release-drafter
         with:
           publish: true


### PR DESCRIPTION
Renovate Dependency Dashboard (#99) に記載されている GitHub Actions のマイナー更新を手動で適用しました。

## 更新内容

- `actions/checkout`: v5.0.0 → v5.0.1
- `jdx/mise-action`: v4.0.1 → v4.2.1
- `actions/cache`: v5.0.5 → v5.1.0
- `release-drafter/release-drafter`: v6 → v6.4.0 (最新のv6パッチ)

対象ファイル:
- `.github/workflows/ci.yml`
- `.github/workflows/copilot-setup-steps.yml`
- `.github/workflows/release.yml`

## スコープ外

以下のメジャーバージョン更新は今回のスコープ外です。

- `actions/checkout` v7.0.0
- `actions/cache` v6.1.0
- `release-drafter/release-drafter` v7

## 確認事項

- 各 action は SHA ピン留めされている場合、既存の `uses: xxx@<sha> # vX.Y.Z` の形式を踏襲してSHAとバージョンコメントを更新しました。
- `pnpm biome:ci` が通ることを確認済みです。
- 3つの workflow ファイルの YAML 構文が正しいことを `js-yaml` でパースして確認しました。