### PR TITLE
READMEにアイコン画像を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # ReadingListAutoSummary
 
+<div align="center">
+
+![icon](images/icons/icon128.png)
+
+</div>
+
 Chrome の Reading List を定期処理し、古い未読記事を既読化しながら本文を要約して Slack に送る拡張です。
 
 ## 主な機能


### PR DESCRIPTION
## 概要
- READMEのタイトル直下に拡張機能の128x128アイコン画像を中央寄せで追加

## テスト
- [x] README.mdのプレビュー表示を確認