### PR TITLE
ci: release-drafter v7スキーマへ移行

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,44 +1,43 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/release-drafter/release-drafter/refs/heads/master/schema.json
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 categories:
   - title: 'BREAKING CHANGES'
-    labels:
-      - 'BREAKING CHANGES'
+    semver-increment: major
+    when:
+      labels:
+        - 'BREAKING CHANGES'
   - title: 'Features'
-    labels:
-      - 'feature'
-      - 'enhancement'
+    semver-increment: minor
+    when:
+      labels:
+        - 'feature'
+        - 'enhancement'
   - title: 'Fixes'
-    labels:
-      - 'fix'
-      - 'bug'
-      - 'security'
+    semver-increment: patch
+    when:
+      labels:
+        - 'fix'
+        - 'bug'
+        - 'security'
   - title: 'Dependencies'
     collapse-after: 3
-    labels:
-      - 'dependencies'
-      - 'renovate'
+    when:
+      labels:
+        - 'dependencies'
+        - 'renovate'
   - title: 'Documentation'
-    labels:
-      - 'document'
-      - 'documentation'
+    when:
+      labels:
+        - 'document'
+        - 'documentation'
   - title: 'Internal improvement'
-    labels:
-      - 'ci'
+    when:
+      labels:
+        - 'ci'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:
-  major:
-    labels:
-      - 'BREAKING CHANGES'
-  minor:
-    labels:
-      - 'feature'
-      - 'enhancement'
-  patch:
-    labels:
-      - 'bug'
-      - 'security'
   default: patch
 template: |
   ## [v$RESOLVED_VERSION](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION)


### PR DESCRIPTION
## 概要

release-drafter v7で非推奨になった設定を移行し、Releaseワークフローで出力されるwarningsを解消します。

## 変更内容

- 各カテゴリの`labels`を`when.labels`へ移動
- バージョン判定をカテゴリの`semver-increment`へ移動
- release-drafter設定のYAMLスキーマを指定

## 確認

- `pnpm biome .github/release-drafter.yml`
- push時の`biome ci .`